### PR TITLE
feat(api): add "remove" alias for "del" method

### DIFF
--- a/unicorn/include/cocaine/detail/zookeeper/errors.hpp
+++ b/unicorn/include/cocaine/detail/zookeeper/errors.hpp
@@ -15,6 +15,7 @@
 */
 
 #pragma once
+
 #include "zookeeper/zookeeper.h"
 
 #include <system_error>

--- a/unicorn/include/cocaine/detail/zookeeper/errors.hpp
+++ b/unicorn/include/cocaine/detail/zookeeper/errors.hpp
@@ -1,0 +1,43 @@
+/*
+    Copyright (c) 2015+ Anton Matveenko <antmat@yandex-team.ru>
+    Copyright (c) 2015+ Other contributors as noted in the AUTHORS file.
+    This file is part of Cocaine.
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "zookeeper/zookeeper.h"
+
+#include <system_error>
+
+namespace cocaine { namespace error {
+
+enum zookeeper_errors {
+    invalid_connection_endpoint = 1,
+    could_not_connect
+};
+auto
+zookeeper_category() -> const std::error_category&;
+
+auto
+make_error_code(zookeeper_errors code) -> std::error_code;
+
+}}
+
+namespace std {
+
+template<>
+struct is_error_code_enum<cocaine::error::zookeeper_errors>:
+public true_type
+{ };
+
+}

--- a/unicorn/include/cocaine/idl/unicorn.hpp
+++ b/unicorn/include/cocaine/idl/unicorn.hpp
@@ -169,6 +169,32 @@ struct unicorn {
         typedef unicorn_final_tag dispatch_type;
     };
 
+    /**
+     * Specially for python users as del is a reserved word in python
+     * It is an alias for del
+     * */
+    struct remove {
+        typedef unicorn_tag tag;
+
+        static const char* alias() {
+            return "remove";
+        }
+
+        /**
+        * delete node. Will only succeed if there are no child nodes.
+        */
+        typedef boost::mpl::list<
+            cocaine::unicorn::path_t,
+            cocaine::unicorn::version_t
+        > argument_type;
+
+        typedef option_of<
+            bool
+        >::tag upstream_type;
+
+        typedef unicorn_final_tag dispatch_type;
+    };
+
     struct increment {
         typedef unicorn_tag tag;
 
@@ -257,6 +283,9 @@ struct protocol<unicorn_tag> {
         unicorn::get,
         unicorn::create,
         unicorn::del,
+
+        // alias for del method
+        unicorn::remove,
         unicorn::increment,
         unicorn::lock
     > messages;

--- a/unicorn/include/cocaine/idl/unicorn.hpp
+++ b/unicorn/include/cocaine/idl/unicorn.hpp
@@ -147,33 +147,10 @@ struct unicorn {
         typedef unicorn_final_tag dispatch_type;
     };
 
-    struct del {
-        typedef unicorn_tag tag;
-
-        static const char* alias() {
-            return "del";
-        }
-
-        /**
-        * delete node. Will only succeed if there are no child nodes.
-        */
-        typedef boost::mpl::list<
-            cocaine::unicorn::path_t,
-            cocaine::unicorn::version_t
-        > argument_type;
-
-        typedef option_of<
-            bool
-        >::tag upstream_type;
-
-        typedef unicorn_final_tag dispatch_type;
-    };
-
     /**
-     * Specially for python users as del is a reserved word in python
-     * It is an alias for del
+     * delete node. replaces del method as "del" is a reserved word in Python
      * */
-    struct remove {
+    struct remove{
         typedef unicorn_tag tag;
 
         static const char* alias() {
@@ -184,15 +161,28 @@ struct unicorn {
         * delete node. Will only succeed if there are no child nodes.
         */
         typedef boost::mpl::list<
-            cocaine::unicorn::path_t,
-            cocaine::unicorn::version_t
+        cocaine::unicorn::path_t,
+        cocaine::unicorn::version_t
         > argument_type;
 
         typedef option_of<
-            bool
+        bool
         >::tag upstream_type;
 
         typedef unicorn_final_tag dispatch_type;
+    };
+
+    /**
+     * Delete node. Deprecated, use remove instead.
+     */
+    struct del: public remove {
+        using remove::tag;
+        using remove::argument_type;
+        using remove::upstream_type;
+        using remove::dispatch_type;
+        static const char* alias() {
+            return "del";
+        }
     };
 
     struct increment {

--- a/unicorn/src/service/unicorn.cpp
+++ b/unicorn/src/service/unicorn.cpp
@@ -121,6 +121,7 @@ typedef unicorn_slot_t<scope::put,       method::put,            resp::put      
 typedef unicorn_slot_t<scope::get,       method::get,            resp::get      > get_slot_t;
 typedef unicorn_slot_t<scope::create,    method::create_default, resp::create   > create_slot_t;
 typedef unicorn_slot_t<scope::del,       method::del,            resp::del      > del_slot_t;
+typedef unicorn_slot_t<scope::remove,    method::del,            resp::del      > remove_slot_t;
 typedef unicorn_slot_t<scope::increment, method::increment,      resp::increment> increment_slot_t;
 typedef unicorn_slot_t<scope::lock,      method::lock,           resp::lock     > lock_slot_t;
 
@@ -148,7 +149,7 @@ unicorn_service_t::unicorn_service_t(context_t& context, asio::io_service& _asio
     on<scope::del>               (std::make_shared<del_slot_t>               (this, unicorn, &api::unicorn_t::del));
 
     // alias for del method
-    on<scope::remove>            (std::make_shared<del_slot_t>               (this, unicorn, &api::unicorn_t::del));
+    on<scope::remove>            (std::make_shared<remove_slot_t>               (this, unicorn, &api::unicorn_t::del));
     on<scope::increment>         (std::make_shared<increment_slot_t>         (this, unicorn, &api::unicorn_t::increment));
     on<scope::lock>              (std::make_shared<lock_slot_t>              (this, unicorn, &api::unicorn_t::lock));
 }

--- a/unicorn/src/service/unicorn.cpp
+++ b/unicorn/src/service/unicorn.cpp
@@ -146,6 +146,9 @@ unicorn_service_t::unicorn_service_t(context_t& context, asio::io_service& _asio
     on<scope::get>               (std::make_shared<get_slot_t>               (this, unicorn, &api::unicorn_t::get));
     on<scope::create>            (std::make_shared<create_slot_t>            (this, unicorn, &api::unicorn_t::create_default));
     on<scope::del>               (std::make_shared<del_slot_t>               (this, unicorn, &api::unicorn_t::del));
+
+    // alias for del method
+    on<scope::remove>            (std::make_shared<del_slot_t>               (this, unicorn, &api::unicorn_t::del));
     on<scope::increment>         (std::make_shared<increment_slot_t>         (this, unicorn, &api::unicorn_t::increment));
     on<scope::lock>              (std::make_shared<lock_slot_t>              (this, unicorn, &api::unicorn_t::lock));
 }


### PR DESCRIPTION
This is needed because "del" is reserved in python, so I added an alias. del is deprecated now, but I won't delete it for API stability.
