### PR TITLE
fix(unicorn): use indexes in callback handler instead of pointers

### DIFF
--- a/unicorn/src/cluster/unicorn.cpp
+++ b/unicorn/src/cluster/unicorn.cpp
@@ -298,7 +298,7 @@ unicorn_cluster_t::announce() {
 
     auto cur_endpoints = actor->endpoints();
 
-    COCAINE_LOG_DEBUG(log, "going to announce self");
+    COCAINE_LOG_INFO(log, "going to announce self");
     if(!endpoints.empty() && cur_endpoints != endpoints) {
         // TODO: fix this case, if ever we would need it
         // This can happen only if actor endpoints have changed
@@ -342,7 +342,7 @@ unicorn_cluster_t::subscribe() {
     );
     subscribe_timer.expires_from_now(boost::posix_time::seconds(config.check_interval));
     subscribe_timer.async_wait(std::bind(&unicorn_cluster_t::on_subscribe_timer, this, std::placeholders::_1));
-    COCAINE_LOG_DEBUG(log, "subscribed for updates on {}", config.path);
+    COCAINE_LOG_INFO(log, "subscribed for updates on path {} (may be prefixed)", config.path);
 }
 
 }}

--- a/unicorn/src/zookeeper/connection.cpp
+++ b/unicorn/src/zookeeper/connection.cpp
@@ -35,7 +35,7 @@ void* c_ptr(Ptr p) {
 
 template <class Ptr>
 void* mc_ptr(Ptr p) {
-    return reinterpret_cast<void*>(static_cast<managed_handler_base_t*>(p));
+    return reinterpret_cast<void*>(p->get_id());
 }
 
 }


### PR DESCRIPTION
Pointers can be reused by allocator, so a race can occur,
when a callback added to handler, released, a new other callback with
same address is added to handler and initial callback is finally called
by zookeeper.
This commit fixes this behaviour.
Also there is a small debug improvement to make future debugging more easy.
To be merged in develop and v0.12.5 branches
