### PR TITLE
feat(node): metrics refactoring

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(${PLUGIN_NAME}
     ${LibCGroup_LIBRARY}
     msgpack
     blackhole
+    metric
     cocaine-core)
 
 set(BUILD_FLAGS "-std=c++0x")

--- a/node/include/cocaine/detail/service/node/engine.hpp
+++ b/node/include/cocaine/detail/service/node/engine.hpp
@@ -112,8 +112,8 @@ public:
     /// \param event an invocation event.
     /// \param id represents slave id to be enqueued (may be none, which means any slave).
     /// \return a tx stream.
-    auto enqueue(std::shared_ptr<api::stream_t> rx, event_t event, boost::optional<id_t> id)
-        -> std::shared_ptr<api::stream_t>;
+    auto enqueue(std::shared_ptr<api::stream_t> rx, event_t event, boost::optional<id_t> id) ->
+        std::shared_ptr<api::stream_t>;
 
     /// Tries to keep alive at least `count` workers no matter what.
     ///

--- a/node/include/cocaine/detail/service/node/stats.hpp
+++ b/node/include/cocaine/detail/service/node/stats.hpp
@@ -3,8 +3,9 @@
 #include <atomic>
 #include <cstdint>
 
-#include <boost/accumulators/framework/accumulator_set.hpp>
-#include <boost/accumulators/statistics.hpp>
+#include <metrics/accumulator/sliding/window.hpp>
+#include <metrics/meter.hpp>
+#include <metrics/timer.hpp>
 
 #include <cocaine/locked_ptr.hpp>
 
@@ -27,29 +28,13 @@ struct stats_t {
         std::atomic<std::uint64_t> crashed;
     } slaves;
 
-    /// Channel processing time quantiles (summary).
-    typedef boost::accumulators::accumulator_set<
-        double,
-        boost::accumulators::stats<
-            boost::accumulators::tag::extended_p_square
-        >
-    > quantiles_t;
+    /// EWMA rates.
+    std::unique_ptr<metrics::meter_t> meter;
 
-    synchronized<quantiles_t> timings;
+    /// Channel processing time quantiles (summary).
+    std::unique_ptr<metrics::timer<metrics::accumulator::sliding::window_t>> timer;
 
     stats_t();
-
-    struct quantile_t {
-        double probability;
-        double value;
-    };
-
-    std::vector<quantile_t>
-    quantiles() const;
-
-private:
-    const std::vector<double>&
-    probabilities() const noexcept;
 };
 
 }  // namespace cocaine

--- a/node/src/node/stats.cpp
+++ b/node/src/node/stats.cpp
@@ -2,61 +2,19 @@
 
 #include <cmath>
 
-#include <boost/accumulators/statistics/extended_p_square.hpp>
-#include <boost/accumulators/statistics/extended_p_square_quantile.hpp>
+#include <metrics/factory.hpp>
 
 namespace cocaine {
 
-namespace {
-
-static const std::vector<double> probabilities_ = {
-    { 0.50, 0.75, 0.90, 0.95, 0.98, 0.99, 0.9995 }
-};
-
-inline
-double
-trunc(double v, uint n) noexcept {
-    BOOST_ASSERT(n < 10);
-
-    static const long long table[10] = {
-        1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
-    };
-
-    return std::ceil(v * table[n]) / table[n];
-}
-
-} // namespace
-
 stats_t::stats_t():
-    timings(boost::accumulators::tag::extended_p_square::probabilities = probabilities_)
+    meter(metrics::factory_t().meter()),
+    timer(metrics::factory_t().timer<metrics::accumulator::sliding::window_t>())
 {
     requests.accepted = 0;
     requests.rejected = 0;
 
     slaves.spawned = 0;
     slaves.crashed = 0;
-}
-
-const std::vector<double>&
-stats_t::probabilities() const noexcept {
-    return probabilities_;
-}
-
-std::vector<stats_t::quantile_t>
-stats_t::quantiles() const {
-    const auto& probs = this->probabilities();
-
-    std::vector<stats_t::quantile_t> result;
-    result.reserve(probs.size());
-
-    timings.apply([&](const quantiles_t& timings) {
-        for (std::size_t i = 0; i < probs.size(); ++i) {
-            const auto quantile = boost::accumulators::extended_p_square(timings)[i];
-            result.push_back({ trunc(100 * probs[i], 2), trunc(quantile, 3) });
-        }
-    });
-
-    return result;
 }
 
 }  // namespace cocaine


### PR DESCRIPTION
- Add rate metric per application as an EWMA for 1, 5, and 15 min.
- Fixed timing percentiles - now it’s more flexible to the load profile.

New fields:

```
"rate": [
    16.838, // EWMA 1 min
    16.945, // EWMA 5 min
    12.517  // EWMA 15 min
],
"rate_mean": 17.038,
```

@noxiouz, @antmat r?
