### PR TITLE
feat: add exp backoff timeout for rebalancing

### DIFF
--- a/node/include/cocaine/detail/service/node/engine.hpp
+++ b/node/include/cocaine/detail/service/node/engine.hpp
@@ -40,6 +40,8 @@ public:
 
     context_t& context;
 
+    std::atomic<bool> stopped;
+
     /// Time point, when the overseer was created.
     const std::chrono::system_clock::time_point birthstamp;
 
@@ -53,8 +55,12 @@ public:
     std::shared_ptr<asio::io_service> loop;
 
     /// Slave pool.
+    // TODO: Seems like we need multichannel queue system with size 1 and timeouts.
     synchronized<pool_type> pool;
     std::atomic<int> pool_target;
+    synchronized<std::unique_ptr<asio::deadline_timer>> on_spawn_rate_timer;
+    std::chrono::system_clock::time_point last_failed;
+    std::chrono::seconds last_timeout;
 
     /// Pending queue.
     synchronized<queue_type> queue;
@@ -160,6 +166,8 @@ private:
     auto rebalance_events() -> void;
 
     auto rebalance_slaves() -> void;
+
+    auto on_spawn_rate_timeout(const std::error_code& ec) -> void;
 };
 
 }  // namespace node

--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -57,11 +57,13 @@ engine_t::engine_t(context_t& context,
                        std::shared_ptr<asio::io_service> loop):
     log(context.log(format("{}/overseer", manifest.name))),
     context(context),
+    stopped(false),
     birthstamp(std::chrono::system_clock::now()),
     manifest_(std::move(manifest)),
     profile_(profile),
     loop(loop),
     pool_target{},
+    last_timeout(std::chrono::seconds(1)),
     stats{}
 {
     COCAINE_LOG_DEBUG(log, "overseer has been initialized");
@@ -544,6 +546,27 @@ auto engine_t::on_handshake(const std::string& id, std::shared_ptr<session_t> se
 
 auto engine_t::on_slave_death(const std::error_code& ec, std::string uuid) -> void {
     if (ec) {
+        on_spawn_rate_timer.apply([&](std::unique_ptr<asio::deadline_timer>& timer) {
+            if (timer) {
+                // We already have fallback timer in progress.
+                // TODO: Increment stats.slaves.timeouted.
+            } else {
+                timer.reset(new asio::deadline_timer(*loop));
+                if (std::chrono::system_clock::now() - last_failed < std::chrono::seconds(32)) { // TODO: Magic.
+                    last_timeout = std::chrono::seconds(std::min(last_timeout.count() * 2, 32LL)); // TODO: Magic.
+                } else {
+                    last_timeout = std::chrono::seconds(1); // TODO: Magic.
+                }
+
+                timer->expires_from_now(boost::posix_time::seconds(last_timeout.count()));
+                timer->async_wait(std::bind(&engine_t::on_spawn_rate_timeout, shared_from_this(), ph::_1));
+
+                COCAINE_LOG_INFO(log, "next rebalance occurs in {} s", last_timeout.count());
+            }
+
+            last_failed = std::chrono::system_clock::now();
+        });
+
         COCAINE_LOG_DEBUG(log, "slave has removed itself from the pool: {}", ec.message());
         ++stats.slaves.crashed;
     } else {
@@ -560,6 +583,15 @@ auto engine_t::on_slave_death(const std::error_code& ec, std::string uuid) -> vo
 
     // TODO: Notify watcher about slave death.
     loop->post(std::bind(&engine_t::rebalance_slaves, shared_from_this()));
+}
+
+auto engine_t::on_spawn_rate_timeout(const std::error_code&) -> void {
+    on_spawn_rate_timer.apply([&](std::unique_ptr<asio::deadline_timer>& timer) {
+        timer.reset();
+    });
+
+    COCAINE_LOG_INFO(log, "rebalancing slaves after exponential backoff timeout");
+    rebalance_slaves();
 }
 
 auto engine_t::rebalance_events() -> void {
@@ -636,6 +668,10 @@ auto engine_t::rebalance_events() -> void {
 }
 
 auto engine_t::rebalance_slaves() -> void {
+    if (stopped) {
+        return;
+    }
+
     using boost::adaptors::filtered;
 
     const auto load = queue->size();
@@ -650,10 +686,16 @@ auto engine_t::rebalance_slaves() -> void {
         profile.pool_limit
     );
 
+    if (*on_spawn_rate_timer.synchronize()) {
+        return;
+    }
+
     pool.apply([&](pool_type& pool) {
         if (pool_target) {
             COCAINE_LOG_DEBUG(log, "attempting to rebalance slaves using direct policy", {
-                {"load", load}, {"slaves", pool.size()}, {"target", target}
+                {"load", load},
+                {"slaves", pool.size()},
+                {"target", target}
             });
 
             if (target <= pool.size()) {

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -21,8 +21,10 @@ overseer_t::overseer_t(context_t& context, manifest_t manifest, profile_t profil
 overseer_t::~overseer_t() {
     COCAINE_LOG_DEBUG(engine->log, "overseer is processing terminate request");
 
+    engine->stopped = true;
     engine->failover(0);
     engine->pool->clear();
+    engine->on_spawn_rate_timer->reset();
 }
 
 auto overseer_t::manifest() const -> manifest_t {


### PR DESCRIPTION
After any slave’s death because unexpected reason there will be rebalancing after 2 ^ N seconds where
N - number of failed attempts during specified large time duration (32 seconds).
This allows to limit spawn rate and not to DOS an external isolation system. Note, that these changes are the first attempt and probably not final.

Obviously Node service already suffers from code bloat and required refactoring and entity decomposition.
