### PR TITLE
refact(node): add request timeout to profile

### DIFF
--- a/node/include/cocaine/service/node/profile.hpp
+++ b/node/include/cocaine/service/node/profile.hpp
@@ -47,6 +47,7 @@ struct profile_t : cached<dynamic_t> {
         unsigned long seal;
         unsigned long terminate;
         unsigned long idle;
+        unsigned long request;
     } timeout;
 
     // Limits.

--- a/node/src/node/profile.cpp
+++ b/node/src/node/profile.cpp
@@ -41,6 +41,7 @@ profile_t::profile_t(context_t& context, const std::string& name_):
     timeout.seal      = static_cast<uint64_t>(1000 * config.at("seal-timeout", 60.0).to<double>());
     timeout.terminate = static_cast<uint64_t>(1000 * config.at("terminate-timeout", 10.0).to<double>());
     timeout.idle      = static_cast<uint64_t>(1000 * config.at("idle-timeout", 600.0f).to<double>());
+    timeout.request   = static_cast<uint64_t>(1000 * config.at("request-timeout", 86400.0f).to<double>());
 
     concurrency         = as_object().at("concurrency", 10L).to<uint64_t>();
     crashlog_limit      = as_object().at("crashlog-limit", 50L).to<uint64_t>();


### PR DESCRIPTION
additional support for timeouts in node service. They can be configured via profile for a group of applications.
