### PR TITLE
feat: publishing policies

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/node/include
+    ${PROJECT_SOURCE_DIR}/node/src
 )
 
 add_library(${PLUGIN_NAME} SHARED

--- a/node/include/cocaine/detail/service/node/engine.hpp
+++ b/node/include/cocaine/detail/service/node/engine.hpp
@@ -17,6 +17,8 @@
 #include "cocaine/detail/service/node/slave/load.hpp"
 #include "cocaine/detail/service/node/stats.hpp"
 
+#include "node/pool_observer.hpp"
+
 namespace cocaine {
 namespace detail {
 namespace service {
@@ -24,6 +26,7 @@ namespace node {
 
 using cocaine::service::node::app::event_t;
 using cocaine::service::node::slave::id_t;
+using cocaine::service::node::pool_observer;
 
 using slave::control_t;
 using slave::load_t;
@@ -61,6 +64,8 @@ public:
     std::chrono::system_clock::time_point last_failed;
     std::chrono::seconds last_timeout;
 
+    pool_observer& observer;
+
     /// Pending queue.
     synchronized<queue_type> queue;
 
@@ -68,10 +73,15 @@ public:
     stats_t stats;
 
 public:
-    engine_t(context_t& context, manifest_t manifest, profile_t profile,
+    engine_t(context_t& context,
+             manifest_t manifest,
+             profile_t profile,
+             pool_observer& observer,
              std::shared_ptr<asio::io_service> loop);
 
     ~engine_t();
+
+    auto active_workers() const -> std::uint32_t;
 
     /// Returns copy of the current manifest.
     ///

--- a/node/include/cocaine/detail/service/node/engine.hpp
+++ b/node/include/cocaine/detail/service/node/engine.hpp
@@ -133,7 +133,7 @@ public:
     /// Tries to keep alive at least `count` workers no matter what.
     ///
     /// Zero value is allowed and means not to spawn workers
-    auto failover(int count) -> void;
+    auto control_population(int count) -> void;
 
     /// Creates a new handshake dispatch, which will be consumed after a new incoming connection
     /// attached.

--- a/node/include/cocaine/idl/node.hpp
+++ b/node/include/cocaine/idl/node.hpp
@@ -114,7 +114,7 @@ struct node {
 struct start_app {
     typedef node_tag tag;
 
-    static const char* alias() {
+    static const char* alias() noexcept {
         return "start_app";
     }
 
@@ -135,6 +135,25 @@ struct pause_app {
      /* Name of the app to susped. */
         std::string
     >::type argument_type;
+};
+
+struct control_app {
+    typedef node_tag tag;
+
+    static const char* alias() noexcept {
+        return "control";
+    }
+
+    typedef boost::mpl::list<
+     /* Name of the application to be controlled. */
+        std::string
+    > argument_type;
+
+    typedef stream_of<
+     /* Number of workers we want the Node Service for App to be kept alive. Non-positive values
+        means rolling back to the default logic. */
+        int
+    >::tag dispatch_type;
 };
 
 struct info {
@@ -194,6 +213,7 @@ struct protocol<node_tag> {
     typedef boost::mpl::list<
         node::start_app,
         node::pause_app,
+        node::control_app,
         node::list,
         node::info
     >::type messages;

--- a/node/include/cocaine/service/node/overseer.hpp
+++ b/node/include/cocaine/service/node/overseer.hpp
@@ -91,7 +91,7 @@ public:
     /// Tries to keep alive at least `count` workers no matter what.
     ///
     /// Zero value is allowed and means not to spawn workers at all.
-    auto failover(int count) -> void;
+    auto control_population(int count) -> void;
 
     /// Creates a new handshake dispatch, which will be consumed after a new incoming connection
     /// attached.

--- a/node/include/cocaine/service/node/overseer.hpp
+++ b/node/include/cocaine/service/node/overseer.hpp
@@ -18,11 +18,16 @@ namespace cocaine {
 namespace service {
 namespace node {
 
+class pool_observer;
+
 class overseer_t {
     std::shared_ptr<engine_t> engine;
 
 public:
-    overseer_t(context_t& context, manifest_t manifest, profile_t profile,
+    overseer_t(context_t& context,
+               manifest_t manifest,
+               profile_t profile,
+               pool_observer& observer,
                std::shared_ptr<asio::io_service> loop);
 
     /// TODO: Docs.
@@ -30,6 +35,9 @@ public:
 
     /// Returns application total uptime in seconds.
     auto uptime() const -> std::chrono::seconds;
+
+    /// Returns number of currently active workers.
+    auto active_workers() const -> std::uint32_t;
 
     /// Returns the copy of current profile, which is used to spawn new slaves.
     ///
@@ -61,7 +69,8 @@ public:
     ///
     /// \return the dispatch object, which is ready for processing the appropriate protocol
     ///     messages.
-    auto enqueue(upstream<io::stream_of<std::string>::tag> downstream, app::event_t event,
+    auto enqueue(upstream<io::stream_of<std::string>::tag> downstream,
+                 app::event_t event,
                  boost::optional<slave::id_t> id) -> std::shared_ptr<client_rpc_dispatch_t>;
 
     /// Enqueues the new event into the most appropriate slave.
@@ -75,7 +84,8 @@ public:
     /// \param id represents slave id to be enqueued (may be none, which means any slave).
     ///
     /// \return a tx stream.
-    auto enqueue(std::shared_ptr<api::stream_t> rx, app::event_t event,
+    auto enqueue(std::shared_ptr<api::stream_t> rx,
+                 app::event_t event,
                  boost::optional<slave::id_t> id) -> std::shared_ptr<api::stream_t>;
 
     /// Tries to keep alive at least `count` workers no matter what.

--- a/node/include/cocaine/service/node/profile.hpp
+++ b/node/include/cocaine/service/node/profile.hpp
@@ -56,13 +56,16 @@ struct profile_t : cached<dynamic_t> {
     unsigned long pool_limit;
     unsigned long queue_limit;
 
+    // Publishing thresholds.
+    auto publish_on() const -> std::uint32_t;
+    auto unpublish_under() const -> std::uint32_t;
+
     // The slave processes are launched in sandboxed environments, called isolates. This one
     // describes the isolate type and arguments.
     struct {
         std::string type;
         dynamic_t args;
     } isolate;
-
 
     // This is a temporal hack not to break ABI
     // Should be located in timeout section

--- a/node/src/node.cpp
+++ b/node/src/node.cpp
@@ -44,10 +44,88 @@
 #include <boost/spirit/include/karma_list.hpp>
 #include <boost/spirit/include/karma_string.hpp>
 
+#include "cocaine/service/node/overseer.hpp"
+
 using namespace cocaine;
 using namespace cocaine::service;
 
+using cocaine::service::node::overseer_t;
+
 namespace ph = std::placeholders;
+
+class control_slot_t:
+    public io::basic_slot<io::node::control_app>
+{
+    struct controlling_slot_t:
+        public io::basic_slot<io::node::control_app>::dispatch_type
+    {
+        typedef io::basic_slot<io::node::control_app>::dispatch_type super;
+
+        typedef io::event_traits<io::node::control_app>::dispatch_type dispatch_type;
+        typedef io::protocol<dispatch_type>::scope protocol;
+
+        control_slot_t* p;
+        std::shared_ptr<overseer_t> overseer;
+
+        controlling_slot_t(const std::string& name, control_slot_t* p_):
+            super("controlling"),
+            p(p_)
+        {
+            overseer = p->parent.overseer(name);
+            if (overseer == nullptr) {
+                throw cocaine::error_t("!");
+            }
+
+            on<protocol::chunk>([&](int size) {
+                overseer->failover(size);
+            });
+
+            p->locked.store(true);
+        }
+
+        ~controlling_slot_t() {
+            p->locked.store(false);
+        }
+
+        virtual
+        void
+        discard(const std::error_code&) const {
+            overseer->failover(0);
+        }
+    };
+
+    typedef std::vector<hpack::header_t> meta_type;
+    typedef std::shared_ptr<const io::basic_slot<io::node::control_app>::dispatch_type> result_type;
+
+    std::atomic<bool> locked;
+    node_t& parent;
+
+public:
+    control_slot_t(node_t& parent):
+        locked(false),
+        parent(parent)
+    {}
+
+    boost::optional<result_type>
+    operator()(tuple_type&& args, upstream_type&& upstream) {
+        return operator()({}, std::move(args), std::move(upstream));
+    }
+
+    boost::optional<result_type>
+    operator()(const meta_type&, tuple_type&& args, upstream_type&& upstream) {
+        typedef io::protocol<io::event_traits<io::node::control_app>::upstream_type>::scope protocol;
+
+        const auto dispatch = tuple::invoke(std::move(args), [&](const std::string& name) -> result_type {
+            if (locked) {
+                upstream.send<protocol::error>(std::make_error_code(std::errc::resource_unavailable_try_again));
+                return nullptr;
+            }
+            return std::make_shared<controlling_slot_t>(name, this);
+        });
+
+        return boost::make_optional(dispatch);
+    }
+};
 
 node_t::node_t(context_t& context, asio::io_service& asio, const std::string& name, const dynamic_t& args):
     category_type(context, asio, name, args),
@@ -55,8 +133,11 @@ node_t::node_t(context_t& context, asio::io_service& asio, const std::string& na
     log(context.log(name)),
     context(context)
 {
-    on<io::node::start_app>(std::bind(&node_t::start_app, this, ph::_1, ph::_2));
+    on<io::node::start_app>([&](const std::string& name, const std::string& profile) {
+        start_app(name, profile);
+    });
     on<io::node::pause_app>(std::bind(&node_t::pause_app, this, ph::_1));
+    on<io::node::control_app>(std::make_shared<control_slot_t>(*this));
     on<io::node::list>     (std::bind(&node_t::list, this));
     on<io::node::info>     (std::bind(&node_t::info, this, ph::_1, ph::_2));
 
@@ -139,7 +220,7 @@ deferred<void>
 node_t::start_app(const std::string& name, const std::string& profile) {
     COCAINE_LOG_DEBUG(log, "processing `start_app` request, app: '{}'", name);
 
-    cocaine::deferred<void> deferred;
+    struct deferred<void> deferred;
 
     apps.apply([&](std::map<std::string, std::shared_ptr<node::app_t>>& apps) {
         auto it = apps.find(name);
@@ -150,7 +231,7 @@ node_t::start_app(const std::string& name, const std::string& profile) {
                 cocaine::format("app '{}' is {}", name, info["state"].as_string()));
         }
 
-        apps.insert({ name, std::make_shared<node::app_t>(context, name, profile, deferred) });
+        apps.insert({name, std::make_shared<node::app_t>(context, name, profile, deferred)});
     });
 
     return deferred;

--- a/node/src/node.cpp
+++ b/node/src/node.cpp
@@ -73,7 +73,7 @@ class control_slot_t:
         {
             overseer = p->parent.overseer(name);
             if (overseer == nullptr) {
-                throw cocaine::error_t("app '{}' is not available");
+                throw cocaine::error_t("app '{}' is not available", name);
             }
 
             on<protocol::chunk>([&](int size) {

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -417,7 +417,7 @@ public:
         }
 
         info["state"] = "running";
-        info["publushed"] = !(context.locate(name) == boost::none);
+        info["publushed"] = static_cast<bool>(context.locate(name));
         return info;
     }
 

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -417,7 +417,7 @@ public:
         }
 
         info["state"] = "running";
-        info["publushed"] = context.locate(name) != boost::none;
+        info["publushed"] = !(context.locate(name) == boost::none);
         return info;
     }
 

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -45,6 +45,7 @@ struct overseer_proxy_t {
 };
 
 // While the client is connected it's okay, balance on numbers depending on received.
+// TODO: Drop when all scripts will be rewritten.
 class control_slot_t:
     public io::basic_slot<io::app::control>
 {
@@ -64,15 +65,9 @@ class control_slot_t:
         {
             on<protocol::chunk>([&](int size) {
                 if (auto overseer = p->overseer.lock()) {
-                    overseer->o->failover(size);
+                    overseer->o->control_population(size);
                 }
             });
-
-            p->locked.store(true);
-        }
-
-        ~controlling_slot_t() {
-            p->locked.store(false);
         }
 
         virtual
@@ -80,7 +75,7 @@ class control_slot_t:
         discard(const std::error_code&) const {
             COCAINE_LOG_DEBUG(p->log, "client has been disappeared, assuming direct control");
             if (auto overseer = p->overseer.lock()) {
-                overseer->o->failover(0);
+                overseer->o->control_population(0);
             }
         }
     };
@@ -89,13 +84,11 @@ class control_slot_t:
     typedef std::shared_ptr<const io::basic_slot<io::app::control>::dispatch_type> result_type;
 
     const std::unique_ptr<logging::logger_t> log;
-    std::atomic<bool> locked;
     std::weak_ptr<overseer_proxy_t> overseer;
 
 public:
     control_slot_t(std::shared_ptr<overseer_proxy_t> overseer_, std::unique_ptr<logging::logger_t> log_):
         log(std::move(log_)),
-        locked(false),
         overseer(overseer_)
     {
         COCAINE_LOG_DEBUG(log, "control slot has been created");
@@ -111,14 +104,8 @@ public:
     }
 
     boost::optional<result_type>
-    operator()(const meta_type&, tuple_type&& args, upstream_type&& upstream) {
-        typedef io::protocol<io::event_traits<io::app::control>::upstream_type>::scope protocol;
-
+    operator()(const meta_type&, tuple_type&& args, upstream_type&&) {
         const auto dispatch = tuple::invoke(std::move(args), [&]() -> result_type {
-            if (locked) {
-                upstream.send<protocol::error>(std::make_error_code(std::errc::resource_unavailable_try_again));
-                return nullptr;
-            }
             return std::make_shared<controlling_slot_t>(this);
         });
 
@@ -408,13 +395,14 @@ public:
     virtual auto spawned() -> void {
         try {
             maybe_publish();
-        } catch (const std::exception&) {}
+        } catch (const std::exception&) {
+            // Probably if we are here than an application is already published earlier. There is
+            // no need to notify anyone about it over and over again.
+        }
     }
 
     virtual auto despawned() -> void {
-        try {
-            maybe_unpublish();
-        } catch (const std::exception&) {}
+        maybe_unpublish();
     }
 
     virtual
@@ -428,11 +416,8 @@ public:
             info["uptime"] = overseer()->uptime().count();
         }
 
-        if (context.locate(name)) {
-            info["state"] = "running (published)";
-        } else {
-            info["state"] = "running (unpublished)";
-        }
+        info["state"] = "running";
+        info["publushed"] = context.locate(name) != boost::none;
         return info;
     }
 

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -429,7 +429,7 @@ public:
         }
 
         if (context.locate(name)) {
-            info["state"] = format("running (published)");
+            info["state"] = "running (published)";
         } else {
             info["state"] = "running (unpublished)";
         }

--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -77,7 +77,15 @@ engine_t::~engine_t() {
 }
 
 auto engine_t::active_workers() const -> std::uint32_t {
-    return pool->size();
+    return pool.apply([&](const pool_type& pool) -> std::uint32_t {
+        std::uint32_t active = 0;
+        for (const auto& kv : pool) {
+            if (kv.second.active()) {
+                ++active;
+            }
+        }
+        return active;
+    });
 }
 
 manifest_t
@@ -339,7 +347,7 @@ auto engine_t::uptime() const -> std::chrono::seconds {
     return std::chrono::duration_cast<std::chrono::seconds>(now - birthstamp);
 }
 
-auto engine_t::failover(int count) -> void {
+auto engine_t::control_population(int count) -> void {
     count = std::max(0, count);
     COCAINE_LOG_DEBUG(log, "changed keep-alive slave count to {}", count);
 

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -10,13 +10,18 @@
 #include "cocaine/detail/service/node/engine.hpp"
 #include "cocaine/detail/service/node/slave.hpp"
 
+#include "pool_observer.hpp"
+
 namespace cocaine {
 namespace service {
 namespace node {
 
-overseer_t::overseer_t(context_t& context, manifest_t manifest, profile_t profile,
+overseer_t::overseer_t(context_t& context,
+                       manifest_t manifest,
+                       profile_t profile,
+                       pool_observer& observer,
                        std::shared_ptr<asio::io_service> loop)
-    : engine(std::make_shared<engine_t>(context, manifest, profile, loop)) {}
+    : engine(std::make_shared<engine_t>(context, manifest, profile, observer, loop)) {}
 
 overseer_t::~overseer_t() {
     COCAINE_LOG_DEBUG(engine->log, "overseer is processing terminate request");
@@ -25,6 +30,10 @@ overseer_t::~overseer_t() {
     engine->failover(0);
     engine->pool->clear();
     engine->on_spawn_rate_timer->reset();
+}
+
+auto overseer_t::active_workers() const -> std::uint32_t {
+    return engine->active_workers();
 }
 
 auto overseer_t::manifest() const -> manifest_t {

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -27,7 +27,7 @@ overseer_t::~overseer_t() {
     COCAINE_LOG_DEBUG(engine->log, "overseer is processing terminate request");
 
     engine->stopped = true;
-    engine->failover(0);
+    engine->control_population(0);
     engine->pool->clear();
     engine->on_spawn_rate_timer->reset();
 }
@@ -52,8 +52,8 @@ auto overseer_t::uptime() const -> std::chrono::seconds {
     return engine->uptime();
 }
 
-auto overseer_t::failover(int count) -> void {
-    return engine->failover(count);
+auto overseer_t::control_population(int count) -> void {
+    return engine->control_population(count);
 }
 
 auto overseer_t::enqueue(upstream<io::stream_of<std::string>::tag> downstream, app::event_t event,

--- a/node/src/node/pool_observer.hpp
+++ b/node/src/node/pool_observer.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace cocaine {
+namespace service {
+namespace node {
+
+class pool_observer {
+public:
+    virtual ~pool_observer() {}
+    virtual auto spawned() -> void = 0;
+    virtual auto despawned() -> void = 0;
+};
+
+}
+}
+}

--- a/node/src/node/profile.cpp
+++ b/node/src/node/profile.cpp
@@ -74,6 +74,14 @@ profile_t::profile_t(context_t& context, const std::string& name_):
     }
 }
 
+auto profile_t::publish_on() const -> std::uint32_t {
+    return this->as_object().at("publish-on", 0u).as_uint();
+}
+
+auto profile_t::unpublish_under() const -> std::uint32_t {
+    return this->as_object().at("unpublish-under", 0u).as_uint();
+}
+
 unsigned long
 profile_t::request_timeout() const {
     return static_cast<uint64_t>(1000 * as_object().at("request-timeout", 86400.0f).to<double>());

--- a/node/src/node/profile.cpp
+++ b/node/src/node/profile.cpp
@@ -76,6 +76,10 @@ profile_t::profile_t(context_t& context, const std::string& name_):
     if (publish_on() > pool_limit) {
         throw cocaine::error_t("publish threshold must not be greater than pool limit");
     }
+
+    if (publish_on() < unpublish_under()) {
+        throw cocaine::error_t("publish threshold must not be less than unpublish one");
+    }
 }
 
 auto profile_t::publish_on() const -> std::uint32_t {

--- a/node/src/node/profile.cpp
+++ b/node/src/node/profile.cpp
@@ -72,6 +72,10 @@ profile_t::profile_t(context_t& context, const std::string& name_):
     if(concurrency == 0) {
         throw cocaine::error_t("engine concurrency must be positive");
     }
+
+    if (publish_on() > pool_limit) {
+        throw cocaine::error_t("publish threshold must not be greater than pool limit");
+    }
 }
 
 auto profile_t::publish_on() const -> std::uint32_t {


### PR DESCRIPTION
This commit allows to control application publishing (and registering with the discovery) process via two additional options. The first one, named `publish-on` gives an application service to publish itself after at least N workers are active. On the other hand the second option - `unpublish-under` unregisters an application when there are less than specified active workers (maybe its buggy or something external required) allowing not to route traffic on them. Great!

@antmat PTAL.
