### PR TITLE
fix(unicorn): add special thread for closing connections to avoid dea…

### DIFF
--- a/unicorn/include/cocaine/detail/zookeeper/connection.hpp
+++ b/unicorn/include/cocaine/detail/zookeeper/connection.hpp
@@ -18,10 +18,15 @@
 #include "cocaine/detail/zookeeper/handler.hpp"
 #include "cocaine/detail/zookeeper/session.hpp"
 
+#include <asio/io_service.hpp>
+
+#include <boost/optional/optional.hpp>
+
 #include <zookeeper/zookeeper.h>
 
 #include <vector>
 #include <string>
+#include <thread>
 
 namespace zookeeper {
 
@@ -137,9 +142,15 @@ private:
     void check_rc(int rc) const;
     void check_connectivity();
     zhandle_t* init();
+    void close(zhandle_t* handle);
     void create_prefix();
     handler_scope_t w_scope;
     managed_watch_handler_base_t& watcher;
+
+    // special loop for closing connections to avoid deadlocks
+    asio::io_service io_loop;
+    boost::optional<asio::io_service::work> work;
+    std::thread close_thread;
 };
 }
 

--- a/unicorn/include/cocaine/detail/zookeeper/connection.hpp
+++ b/unicorn/include/cocaine/detail/zookeeper/connection.hpp
@@ -18,6 +18,8 @@
 #include "cocaine/detail/zookeeper/handler.hpp"
 #include "cocaine/detail/zookeeper/session.hpp"
 
+#include <cocaine/locked_ptr.hpp>
+
 #include <asio/io_service.hpp>
 
 #include <boost/optional/optional.hpp>
@@ -65,6 +67,8 @@ private:
 */
 class connection_t {
 public:
+    typedef std::shared_ptr<zhandle_t> handle_ptr;
+
     connection_t(const cfg_t& cfg, const session_t& session);
     connection_t(const connection_t&) = delete;
     connection_t& operator=(const connection_t&) = delete;
@@ -134,14 +138,16 @@ private:
         connection_t& parent;
     };
 
+    void reconnect(handle_ptr& old_handle);
     path_t format_path(const path_t path);
+    handle_ptr zhandle();
 
     cfg_t cfg;
     session_t session;
-    zhandle_t* zhandle;
+    cocaine::synchronized<handle_ptr> _zhandle;
     void check_rc(int rc) const;
     void check_connectivity();
-    zhandle_t* init();
+    handle_ptr init();
     void close(zhandle_t* handle);
     void create_prefix();
     handler_scope_t w_scope;

--- a/unicorn/src/zookeeper/connection.cpp
+++ b/unicorn/src/zookeeper/connection.cpp
@@ -79,7 +79,7 @@ cfg_t::connection_string() const {
 zookeeper::connection_t::connection_t(const cfg_t& _cfg, const session_t& _session) :
     cfg(_cfg),
     session(_session),
-    zhandle(),
+    _zhandle(),
     w_scope(),
     watcher(w_scope.get_handler<reconnect_action_t>(*this)),
     io_loop(),
@@ -92,13 +92,13 @@ zookeeper::connection_t::connection_t(const cfg_t& _cfg, const session_t& _sessi
     while(!cfg.prefix.empty() && cfg.prefix.back() == '/') {
         cfg.prefix.resize(cfg.prefix.size() - 1);
     }
-    reconnect();
+    _zhandle.apply([&](handle_ptr& h) {
+        reconnect(h);
+    });
 }
 
 zookeeper::connection_t::~connection_t() {
-    if(zhandle) {
-        close(zhandle);
-    }
+    _zhandle->reset();
     work = boost::none;
     close_thread.join();
 }
@@ -110,12 +110,18 @@ path_t zookeeper::connection_t::format_path(const path_t path) {
     return cfg.prefix + path;
 }
 
+connection_t::handle_ptr connection_t::zhandle(){
+    return _zhandle.apply([&](handle_ptr& handle){
+        return handle;
+    });
+}
+
 void
 connection_t::put(const path_t& path, const value_t& value, version_t version, managed_stat_handler_base_t& handler) {
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_aset(zhandle, prefixed_path.c_str(), value.c_str(), value.size(), version, &handler_dispatcher_t::stat_cb, mc_ptr(&handler))
+        zoo_aset(zhandle().get(), prefixed_path.c_str(), value.c_str(), value.size(), version, &handler_dispatcher_t::stat_cb, mc_ptr(&handler))
     );
 }
 
@@ -124,7 +130,7 @@ connection_t::get(const path_t& path, managed_data_handler_base_t& handler, mana
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_awget(zhandle, prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, mc_ptr(&watch), &handler_dispatcher_t::data_cb, mc_ptr(&handler))
+        zoo_awget(zhandle().get(), prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, mc_ptr(&watch), &handler_dispatcher_t::data_cb, mc_ptr(&handler))
     );
 }
 
@@ -133,7 +139,7 @@ connection_t::get(const path_t& path, managed_data_handler_base_t& handler) {
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_awget(zhandle, prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, nullptr, &handler_dispatcher_t::data_cb, mc_ptr(&handler))
+        zoo_awget(zhandle().get(), prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, nullptr, &handler_dispatcher_t::data_cb, mc_ptr(&handler))
     );
 }
 
@@ -146,7 +152,7 @@ connection_t::create(const path_t& path, const value_t& value, bool ephemeral, b
     flag = flag | (sequence ? ZOO_SEQUENCE : 0);
     handler.set_prefix(cfg.prefix);
     check_rc(
-        zoo_acreate(zhandle, prefixed_path.c_str(), value.c_str(), value.size(), &acl, flag, &handler_dispatcher_t::string_cb, mc_ptr(&handler))
+        zoo_acreate(zhandle().get(), prefixed_path.c_str(), value.c_str(), value.size(), &acl, flag, &handler_dispatcher_t::string_cb, mc_ptr(&handler))
     );
 }
 
@@ -155,7 +161,7 @@ connection_t::del(const path_t& path, version_t version, std::unique_ptr<void_ha
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_adelete(zhandle, prefixed_path.c_str(), version, &handler_dispatcher_t::void_cb, c_ptr(handler.get()))
+        zoo_adelete(zhandle().get(), prefixed_path.c_str(), version, &handler_dispatcher_t::void_cb, c_ptr(handler.get()))
     );
     handler.release();
 }
@@ -165,7 +171,7 @@ connection_t::exists(const path_t& path, managed_stat_handler_base_t& handler, m
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_awexists(zhandle, prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, mc_ptr(&watch), &handler_dispatcher_t::stat_cb, mc_ptr(&handler))
+        zoo_awexists(zhandle().get(), prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, mc_ptr(&watch), &handler_dispatcher_t::stat_cb, mc_ptr(&handler))
     );
 }
 
@@ -174,7 +180,7 @@ connection_t::childs(const path_t& path, managed_strings_stat_handler_base_t& ha
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_awget_children2(zhandle, prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, mc_ptr(&watch), &handler_dispatcher_t::strings_stat_cb, mc_ptr(&handler))
+        zoo_awget_children2(zhandle().get(), prefixed_path.c_str(), &handler_dispatcher_t::watcher_cb, mc_ptr(&watch), &handler_dispatcher_t::strings_stat_cb, mc_ptr(&handler))
     );
 }
 
@@ -183,14 +189,16 @@ connection_t::childs(const path_t& path, managed_strings_stat_handler_base_t& ha
     check_connectivity();
     auto prefixed_path = format_path(path);
     check_rc(
-        zoo_awget_children2(zhandle, prefixed_path.c_str(), nullptr, nullptr, &handler_dispatcher_t::strings_stat_cb, mc_ptr(&handler))
+        zoo_awget_children2(zhandle().get(), prefixed_path.c_str(), nullptr, nullptr, &handler_dispatcher_t::strings_stat_cb, mc_ptr(&handler))
     );
 }
 
 void connection_t::check_connectivity() {
-    if(!zhandle || is_unrecoverable(zhandle)) {
-        reconnect();
-    }
+    _zhandle.apply([&](handle_ptr& handle) {
+        if(!handle.get() || is_unrecoverable(handle.get())) {
+            reconnect(handle);
+        }
+    });
 }
 
 void connection_t::check_rc(int rc) const {
@@ -201,38 +209,41 @@ void connection_t::check_rc(int rc) const {
 }
 
 void connection_t::reconnect() {
+    _zhandle.apply([&](handle_ptr& h) {
+        reconnect(h);
+    });
+}
 
-    zhandle_t* new_zhandle = init();
-    if(!new_zhandle || is_unrecoverable(new_zhandle)) {
+void connection_t::reconnect(handle_ptr& old_zhandle) {
+
+    handle_ptr new_zhandle = init();
+    if(!new_zhandle.get() || is_unrecoverable(new_zhandle.get())) {
         if(session.valid()) {
             //Try to reset session before second attempt
             session.reset();
             new_zhandle = init();
         }
-        if(!new_zhandle || is_unrecoverable(new_zhandle)) {
+        if(!new_zhandle.get() || is_unrecoverable(new_zhandle.get())) {
             // Swap in any case.
             // Sometimes we really want to force reconnect even when zk is unavailable at all. For example on lock release.
-            std::swap(new_zhandle, zhandle);
-            close(new_zhandle);
             throw std::system_error(cocaine::error::could_not_connect);
         }
     } else {
         if(!session.valid()) {
-            session.assign(*zoo_client_id(new_zhandle));
+            session.assign(*zoo_client_id(new_zhandle.get()));
         }
     }
-    std::swap(new_zhandle, zhandle);
-    close(new_zhandle);
+    old_zhandle.swap(new_zhandle);
 }
 
-zhandle_t* connection_t::init() {
+connection_t::handle_ptr connection_t::init() {
     zhandle_t* new_zhandle = zookeeper_init(cfg.connection_string().c_str(),
                                             &handler_dispatcher_t::watcher_cb,
                                             cfg.recv_timeout_ms,
                                             session.native(),
                                             mc_ptr(&watcher),
                                             0);
-    return new_zhandle;
+    return handle_ptr(new_zhandle, std::bind(&connection_t::close, this, std::placeholders::_1));
 }
 
 void connection_t::close(zhandle_t* handle) {
@@ -248,9 +259,11 @@ void connection_t::create_prefix() {
         int flag = 0;
         for (size_t i = count; i > 0; i--) {
             auto path = path_parent(cfg.prefix, i - 1);
-            int rc = zoo_create(zhandle, path.c_str(), "", 0, &acl, flag, NULL, 0);
+            int rc = zoo_create(zhandle().get(), path.c_str(), "", 0, &acl, flag, NULL, 0);
             if (rc && rc != ZNODEEXISTS) {
-                reconnect();
+                _zhandle.apply([&](handle_ptr& h){
+                    reconnect(h);
+                });
             }
         }
     }
@@ -263,7 +276,9 @@ void connection_t::reconnect_action_t::watch_event(int type, int state, path_t /
         if(state == ZOO_EXPIRED_SESSION_STATE) {
             try {
                 parent.session.reset();
-                parent.reconnect();
+                parent._zhandle.apply([&](handle_ptr& h){
+                    parent.reconnect(h);
+                });
             } catch (const std::system_error& e) {
                 // Swallow it and leave connection in disconnected state.
                 // That's all we can do if ZK is unavailable.

--- a/unicorn/src/zookeeper/connection.cpp
+++ b/unicorn/src/zookeeper/connection.cpp
@@ -226,6 +226,7 @@ void connection_t::reconnect(handle_ptr& old_zhandle) {
         if(!new_zhandle.get() || is_unrecoverable(new_zhandle.get())) {
             // Swap in any case.
             // Sometimes we really want to force reconnect even when zk is unavailable at all. For example on lock release.
+            old_zhandle.swap(new_zhandle);
             throw std::system_error(cocaine::error::could_not_connect);
         }
     } else {

--- a/unicorn/test/run.rb
+++ b/unicorn/test/run.rb
@@ -237,7 +237,7 @@ describe :Unicorn do
     expect(result[1][0][1]).to eq -1
     expect{
       rx.recv(fast_timeout)
-    }.to raise_error(Celluloid::TaskTimeout)
+    }.to raise_error(Celluloid::TimeoutError)
     ensure_create(node, node_val)
     result = rx.recv(fast_timeout)
     expect(result[1][0][0]).to eq node_val
@@ -245,7 +245,7 @@ describe :Unicorn do
 
     expect{
       rx.recv(fast_timeout)
-    }.to raise_error(Celluloid::TaskTimeout)
+    }.to raise_error(Celluloid::TimeoutError)
     ensure_del(node)
     result = rx.recv(fast_timeout)
     expect(result[1][0][0]).to eq ZK_ERROR_CATEGORY
@@ -255,7 +255,7 @@ describe :Unicorn do
     ensure_create(node, node_val)
     expect{
       rx.recv(fast_timeout)
-    }.to raise_error(Celluloid::TaskTimeout)
+    }.to raise_error(Celluloid::TimeoutError)
 
     ensure_del(node)
     tx.close
@@ -420,7 +420,7 @@ describe :Unicorn do
       expect(Set.new(result[1][1])).to eq subnodes
       expect{
         rx.recv(fast_timeout)
-      }.to raise_error(Celluloid::TaskTimeout)
+      }.to raise_error(Celluloid::TimeoutError)
     end
     for subnode in subnodes.to_a do
       ensure_del(node + '/' + subnode)
@@ -431,7 +431,7 @@ describe :Unicorn do
       expect(Set.new(result[1][1])).to eq subnodes
       expect{
         rx.recv(fast_timeout)
-      }.to raise_error(Celluloid::TaskTimeout)
+      }.to raise_error(Celluloid::TimeoutError)
     end
     ensure_del(node)
     result = rx.recv
@@ -451,7 +451,7 @@ describe :Unicorn do
     tx2, rx2 = unicorn2.lock(node)
     expect{
       rx2.recv(fast_timeout)
-    }.to raise_error(Celluloid::TaskTimeout)
+    }.to raise_error(Celluloid::TimeoutError)
 
     tx.close
     result = rx2.recv


### PR DESCRIPTION
If connection is loss and reestablished from ZK callback that can lead to inifinite join and deadlock.
I don't see a better way now, except closing connections in a separate thread.