### PR TITLE
refactor: adapt to new metrics features

### DIFF
--- a/metrics/include/cocaine/idl/metrics.hpp
+++ b/metrics/include/cocaine/idl/metrics.hpp
@@ -41,9 +41,9 @@ struct metrics {
         }
 
         typedef boost::mpl::vector<
-         /* Output type. Allowed plain (default) and json. */
+         /* Output type. Allowed plain (default) and json tree. */
             optional<std::string>,
-         /* Query. */
+         /* Query AST. */
             optional<dynamic_t>
         >::type argument_type;
 

--- a/metrics/include/cocaine/idl/metrics.hpp
+++ b/metrics/include/cocaine/idl/metrics.hpp
@@ -40,6 +40,13 @@ struct metrics {
             return "fetch";
         }
 
+        typedef boost::mpl::vector<
+         /* Output type. Allowed plain (default) and json. */
+            optional<std::string>,
+         /* Query. */
+            optional<dynamic_t>
+        >::type argument_type;
+
         typedef option_of<
             dynamic_t
         >::tag upstream_type;

--- a/metrics/include/cocaine/service/metrics.hpp
+++ b/metrics/include/cocaine/service/metrics.hpp
@@ -40,22 +40,42 @@ class metrics_t :
     public dispatch<io::metrics_tag>
 {
 public:
+    enum class type_t {
+        json,
+        plain
+    };
+
+public:
     metrics_t(context_t& context,
               asio::io_service& asio,
               const std::string& name,
               const dynamic_t& args);
 
-    auto prototype() const -> const io::basic_dispatch_t& {
+    auto
+    prototype() const -> const io::basic_dispatch_t& {
         return *this;
     }
 
     /// Returns metrics dump.
-    auto metrics(std::string type, const dynamic_t& query) const -> dynamic_t;
+    auto
+    metrics(const std::string& type, const dynamic_t& query) const -> dynamic_t;
+
+private:
+    auto
+    make_type(const std::string& type) const -> type_t;
+
+    auto
+    make_filter(const dynamic_t& query) const -> libmetrics::query_t;
+
+    auto
+    construct_plain(const libmetrics::query_t& filter) const -> dynamic_t;
+
+    auto
+    construct_dendroid(const libmetrics::query_t& filter) const -> dynamic_t;
 
 private:
     libmetrics::registry_t& hub;
     std::vector<api::sender_ptr> senders;
-
     std::shared_ptr<metrics::factory_t> factory;
 };
 

--- a/metrics/include/cocaine/service/metrics.hpp
+++ b/metrics/include/cocaine/service/metrics.hpp
@@ -30,10 +30,15 @@
 #include <cocaine/idl/metrics.hpp>
 #include <cocaine/rpc/dispatch.hpp>
 
+#include "metrics/fwd.hpp"
+
 namespace cocaine {
 namespace service {
 
-class metrics_t : public api::service_t, public dispatch<io::metrics_tag> {
+class metrics_t :
+    public api::service_t,
+    public dispatch<io::metrics_tag>
+{
 public:
     metrics_t(context_t& context,
               asio::io_service& asio,
@@ -45,11 +50,13 @@ public:
     }
 
     /// Returns metrics dump.
-    auto metrics() const -> dynamic_t;
+    auto metrics(std::string type, const dynamic_t& query) const -> dynamic_t;
 
 private:
-    metrics::registry_t& hub;
+    libmetrics::registry_t& hub;
     std::vector<api::sender_ptr> senders;
+
+    std::shared_ptr<metrics::factory_t> factory;
 };
 
 }  // namespace service

--- a/metrics/include/cocaine/service/metrics/fwd.hpp
+++ b/metrics/include/cocaine/service/metrics/fwd.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace cocaine {
+namespace service {
+
+namespace libmetrics = ::metrics;
+
+namespace metrics {
+
+class filter_t;
+class factory_t;
+
+} // namespace metrics
+} // namespace service
+} // namespace cocaine

--- a/metrics/src/service/metrics.cpp
+++ b/metrics/src/service/metrics.cpp
@@ -21,6 +21,15 @@
 namespace cocaine {
 namespace service {
 
+namespace {
+
+const std::array<std::tuple<std::string, metrics_t::type_t>, 2> types = {{
+    std::make_tuple("json", metrics_t::type_t::json),
+    std::make_tuple("plain", metrics_t::type_t::plain)
+}};
+
+}  // namespace
+
 metrics_t::metrics_t(context_t& context,
                      asio::io_service& asio,
                      const std::string& _name,
@@ -50,30 +59,66 @@ metrics_t::metrics_t(context_t& context,
     });
 }
 
-auto metrics_t::metrics(std::string type, const dynamic_t& query) const -> dynamic_t {
-    if (type.empty()) {
-        type = "plain";
-    }
+auto metrics_t::metrics(const std::string& type, const dynamic_t& query) const -> dynamic_t {
+    const auto ty = make_type(type);
+    const auto filter = make_filter(query);
 
-    libmetrics::query_t filter = [](const libmetrics::tags_t&) -> bool {
-        return true;
-    };
-
-    if (!query.is_null()) {
-        filter = factory->construct_query(query);
-    }
-
-    dynamic_t::object_t out;
-    if (type == "json") {
-        for (const auto& metric : hub.select(filter)) {
-            metrics::dendroid_t visitor(metric->name(), out);
-            metric->apply(visitor);
-        }
+    if (ty == type_t::json) {
+        return construct_dendroid(filter);
     } else {
-        for (const auto& metric : hub.select(filter)) {
-            metrics::plain_t visitor(metric->name(), out);
-            metric->apply(visitor);
+        return construct_plain(filter);
+    }
+}
+
+auto
+metrics_t::make_type(const std::string& type) const -> type_t {
+    if (type.empty()) {
+        return type_t::plain;
+    }
+
+    const auto it = std::find_if(
+        std::begin(types),
+        std::end(types),
+        [&](const std::tuple<std::string, metrics_t::type_t>& ty) -> bool {
+            return std::get<0>(ty) == type;
         }
+    );
+
+    if (it == std::end(types)) {
+        throw cocaine::error_t("unknown output type");
+    }
+
+    return std::get<1>(*it);
+}
+
+auto
+metrics_t::make_filter(const dynamic_t& query) const -> libmetrics::query_t {
+    if (query.is_null()) {
+        return [](const libmetrics::tags_t&) -> bool {
+            return true;
+        };
+    } else {
+        return factory->construct_query(query);
+    }
+}
+
+auto
+metrics_t::construct_plain(const libmetrics::query_t& filter) const -> dynamic_t {
+    dynamic_t::object_t out;
+    for (const auto& metric : hub.select(filter)) {
+        metrics::plain_t visitor(metric->name(), out);
+        metric->apply(visitor);
+    }
+
+    return out;
+}
+
+auto
+metrics_t::construct_dendroid(const libmetrics::query_t& filter) const -> dynamic_t {
+    dynamic_t::object_t out;
+    for (const auto& metric : hub.select(filter)) {
+        metrics::dendroid_t visitor(metric->name(), out);
+        metric->apply(visitor);
     }
 
     return out;

--- a/metrics/src/service/metrics/factory.hpp
+++ b/metrics/src/service/metrics/factory.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <metrics/fwd.hpp>
+
+#include "filter.hpp"
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+
+class factory_t {
+    std::unordered_map<std::string, std::shared_ptr<filter_t>> filters;
+
+public:
+    auto
+    add(std::shared_ptr<filter_t> filter) -> void {
+        filters[filter->name()] = std::move(filter);
+    }
+
+    auto
+    construct(const std::string& name, const dynamic_t::array_t& args) const -> libmetrics::query_t {
+        if (filters.count(name) == 0) {
+            throw cocaine::error_t("unknown filter function \"{}\"", name);
+        }
+
+        const auto& filter = filters.at(name);
+        if (auto arity = filter->arity()) {
+            if (*arity != args.size()) {
+                throw cocaine::error_t("expected {} arguments for filter \"{}\", found {}",
+                    *arity, name, args.size());
+            }
+        }
+
+        return filter->create(*this, args);
+    }
+
+    auto
+    construct_query(const dynamic_t& query) const -> libmetrics::query_t {
+        if (!query.is_object()) {
+            throw cocaine::error_t("query object must be an object");
+        }
+
+        auto in = query.as_object();
+        if (in.size() != 1) {
+            throw cocaine::error_t("query function must have exactly one name");
+        }
+
+        const auto& name = std::begin(in)->first;
+        const auto& args = std::begin(in)->second.as_array();
+
+        return construct(name, args);
+    }
+};
+
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/filter.hpp
+++ b/metrics/src/service/metrics/filter.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <boost/optional/optional.hpp>
+
+#include <cocaine/forwards.hpp>
+
+#include "cocaine/service/metrics/fwd.hpp"
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+
+class filter_t {
+public:
+    virtual ~filter_t() = default;
+
+    virtual auto
+    name() const -> const char* = 0;
+
+    virtual auto
+    arity() const -> boost::optional<std::size_t> = 0;
+
+    virtual auto
+    create(const factory_t& factory, const dynamic_t::array_t& args) const -> libmetrics::query_t = 0;
+};
+
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/filter/and.hpp
+++ b/metrics/src/service/metrics/filter/and.hpp
@@ -1,0 +1,49 @@
+#include "../filter.hpp"
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+namespace filter {
+
+class and_t : public filter_t {
+public:
+    auto
+    name() const -> const char* override {
+        return "and";
+    }
+
+    auto
+    arity() const -> boost::optional<std::size_t> override {
+        return boost::none;
+    }
+
+    auto
+    create(const factory_t& factory, const dynamic_t::array_t& args) const ->
+        libmetrics::query_t override
+    {
+        std::vector<libmetrics::query_t> functions;
+        std::transform(
+            std::begin(args),
+            std::end(args),
+            std::back_inserter(functions),
+            [&](const dynamic_t& arg) {
+                return factory.construct_query(arg);
+            }
+        );
+
+        return [=](const libmetrics::tags_t& tags) -> bool {
+            return std::all_of(
+                std::begin(functions),
+                std::end(functions),
+                [&](const libmetrics::query_t& q) -> bool {
+                    return q(tags);
+                }
+            );
+        };
+    }
+};
+
+}  // namespace filter
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/filter/contains.hpp
+++ b/metrics/src/service/metrics/filter/contains.hpp
@@ -1,0 +1,36 @@
+#include "../filter.hpp"
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+namespace filter {
+
+class contains_t : public filter_t {
+public:
+    auto
+    name() const -> const char* override {
+        return "contains";
+    }
+
+    auto
+    arity() const -> boost::optional<std::size_t> override {
+        return 2;
+    }
+
+    auto
+    create(const factory_t&, const dynamic_t::array_t& args) const ->
+        libmetrics::query_t override
+    {
+        auto name = args[0].as_string();
+        auto value = args[1].as_string();
+        return [=](const libmetrics::tags_t& tags) -> bool {
+            const auto tag = tags.tag(name);
+            return tag && tag->find(value) != std::string::npos;
+        };
+    }
+};
+
+}  // namespace filter
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/filter/eq.hpp
+++ b/metrics/src/service/metrics/filter/eq.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../filter.hpp"
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+namespace filter {
+
+class eq_t : public filter_t {
+public:
+    auto
+    name() const -> const char* override {
+        return "eq";
+    }
+
+    auto
+    arity() const -> boost::optional<std::size_t> override {
+        return 2;
+    }
+
+    auto
+    create(const factory_t&, const dynamic_t::array_t& args) const ->
+        libmetrics::query_t override
+    {
+        auto name = args[0].as_string();
+        auto value = args[1].as_string();
+        return [=](const libmetrics::tags_t& tags) -> bool {
+            return tags.tag(name) == boost::optional<const std::string&>(value);
+        };
+    }
+};
+
+}  // namespace filter
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/filter/or.hpp
+++ b/metrics/src/service/metrics/filter/or.hpp
@@ -1,0 +1,49 @@
+#include "../filter.hpp"
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+namespace filter {
+
+class or_t : public filter_t {
+public:
+    auto
+    name() const -> const char* override {
+        return "or";
+    }
+
+    auto
+    arity() const -> boost::optional<std::size_t> override {
+        return boost::none;
+    }
+
+    auto
+    create(const factory_t& factory, const dynamic_t::array_t& args) const ->
+        libmetrics::query_t override
+    {
+        std::vector<libmetrics::query_t> functions;
+        std::transform(
+            std::begin(args),
+            std::end(args),
+            std::back_inserter(functions),
+            [&](const dynamic_t& arg) {
+                return factory.construct_query(arg);
+            }
+        );
+
+        return [=](const libmetrics::tags_t& tags) -> bool {
+            return std::any_of(
+                std::begin(functions),
+                std::end(functions),
+                [&](const libmetrics::query_t& q) -> bool {
+                    return q(tags);
+                }
+            );
+        };
+    }
+};
+
+}  // namespace filter
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/visitor/dendroid.hpp
+++ b/metrics/src/service/metrics/visitor/dendroid.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
+
+#include <metrics/accumulator/sliding/window.hpp>
+#include <metrics/accumulator/snapshot/uniform.hpp>
+#include <metrics/meter.hpp>
+#include <metrics/timer.hpp>
+#include <metrics/visitor.hpp>
+
+#include <cocaine/dynamic.hpp>
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+
+class dendroid_t : public libmetrics::visitor_t {
+    std::vector<std::string> m_parts;
+    std::reference_wrapper<dynamic_t::object_t> m_out;
+
+public:
+    dendroid_t(const std::string& name, dynamic_t::object_t& out) :
+        m_out(out)
+    {
+        boost::split(m_parts, name, boost::is_any_of("."), boost::token_compress_on);
+        if (m_parts.empty()) {
+            throw cocaine::error_t("metric name must contain at least one alphanumeric character");
+        }
+    }
+
+    auto visit(const libmetrics::gauge<std::int64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::gauge<std::uint64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::gauge<std::double_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const std::atomic<std::int64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const std::atomic<std::uint64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::meter_t& metric) -> void override {
+        traverse();
+        auto& out = m_out.get();
+        out["count"] = metric.count();
+        out["m01rate"] = metric.m01rate();
+        out["m05rate"] = metric.m05rate();
+        out["m15rate"] = metric.m15rate();
+    }
+
+    auto visit(const libmetrics::timer<libmetrics::accumulator::sliding::window_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+private:
+    template<typename T>
+    auto do_visit(const libmetrics::gauge<T>& metric) -> void {
+        const auto name = m_parts.back();
+        m_parts.pop_back();
+
+        traverse();
+        auto& out = m_out.get();
+        out[name] = metric();
+    }
+
+    template<typename T>
+    auto do_visit(const std::atomic<T>& metric) -> void {
+        const auto name = m_parts.back();
+        m_parts.pop_back();
+
+        traverse();
+        auto& out = m_out.get();
+        out[name] = metric.load();
+    }
+
+    template<typename T>
+    auto do_visit(const libmetrics::timer<T>& metric) -> void {
+        traverse();
+        auto& out = m_out.get();
+        out["count"] = metric.count();
+        out["m01rate"] = metric.m01rate();
+        out["m05rate"] = metric.m05rate();
+        out["m15rate"] = metric.m15rate();
+
+        const auto snapshot = metric.snapshot();
+        out["p50"] = snapshot.median() / 1e6;
+        out["p75"] = snapshot.p75() / 1e6;
+        out["p90"] = snapshot.p90() / 1e6;
+        out["p95"] = snapshot.p95() / 1e6;
+        out["p98"] = snapshot.p98() / 1e6;
+        out["p99"] = snapshot.p99() / 1e6;
+        out["mean"] = snapshot.mean() / 1e6;
+        out["stddev"] = snapshot.stddev() / 1e6;
+    }
+
+private:
+    auto
+    traverse() -> void {
+        for (const auto& part : m_parts) {
+            if (!m_out.get()[part].is_object()) {
+                m_out.get()[part] = dynamic_t::object_t();
+            }
+            m_out = m_out.get()[part].as_object();
+        }
+    }
+};
+
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine

--- a/metrics/src/service/metrics/visitor/plain.hpp
+++ b/metrics/src/service/metrics/visitor/plain.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <metrics/accumulator/sliding/window.hpp>
+#include <metrics/accumulator/snapshot/uniform.hpp>
+#include <metrics/meter.hpp>
+#include <metrics/timer.hpp>
+#include <metrics/visitor.hpp>
+
+namespace cocaine {
+namespace service {
+namespace metrics {
+
+class plain_t : public libmetrics::visitor_t {
+    const std::string m_name;
+    dynamic_t::object_t& m_out;
+
+public:
+    plain_t(const std::string& name, dynamic_t::object_t& out) :
+        m_name(name),
+        m_out(out)
+    {}
+
+    auto visit(const libmetrics::gauge<std::int64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::gauge<std::uint64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::gauge<std::double_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const std::atomic<std::int64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const std::atomic<std::uint64_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::meter_t& metric) -> void override {
+        m_out[m_name + ".count"] = metric.count();
+        m_out[m_name + ".m01rate"] = metric.m01rate();
+        m_out[m_name + ".m05rate"] = metric.m05rate();
+        m_out[m_name + ".m15rate"] = metric.m15rate();
+    }
+
+    auto visit(const libmetrics::timer<libmetrics::accumulator::sliding::window_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+private:
+    template<typename T>
+    auto do_visit(const libmetrics::gauge<T>& metric) -> void {
+        m_out[m_name] = metric();
+    }
+
+    template<typename T>
+    auto do_visit(const std::atomic<T>& metric) -> void {
+        m_out[m_name] = metric.load();
+    }
+
+    template<typename T>
+    auto do_visit(const libmetrics::timer<T>& metric) -> void {
+        m_out[m_name + ".count"] = metric.count();
+        m_out[m_name + ".m01rate"] = metric.m01rate();
+        m_out[m_name + ".m05rate"] = metric.m05rate();
+        m_out[m_name + ".m15rate"] = metric.m15rate();
+
+        const auto snapshot = metric.snapshot();
+        m_out[m_name + ".p50"] = snapshot.median() / 1e6;
+        m_out[m_name + ".p75"] = snapshot.p75() / 1e6;
+        m_out[m_name + ".p90"] = snapshot.p90() / 1e6;
+        m_out[m_name + ".p95"] = snapshot.p95() / 1e6;
+        m_out[m_name + ".p98"] = snapshot.p98() / 1e6;
+        m_out[m_name + ".p99"] = snapshot.p99() / 1e6;
+        m_out[m_name + ".mean"] = snapshot.mean() / 1e6;
+        m_out[m_name + ".stddev"] = snapshot.stddev() / 1e6;
+    }
+};
+
+}  // namespace metrics
+}  // namespace service
+}  // namespace cocaine


### PR DESCRIPTION
New `libmetrics` select API with visitable support allows not to miss some type of metrics during its serialization.