### PR TITLE
Metrics gcc fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.11.0-alpha2) unstable; urgency=low
+
+  * Fixed: build on GCC.
+
+ -- Anton Matveenko <antmat@me.com>  Thu, 22 Dec 2016 14:45:29 +0300
+
 cocaine-plugins (0.12.11.0-alpha1) unstable; urgency=low
 
   * Added: Vicodyn - virtual cocaine dynamic proxy.

--- a/metrics/src/service/metrics/extract.hpp
+++ b/metrics/src/service/metrics/extract.hpp
@@ -22,7 +22,7 @@ class const_t : public node_factory<dynamic_t> {
 
     auto
     children() const -> boost::optional<std::size_t> override {
-        return 1;
+        return 1ul;
     }
 
     auto
@@ -43,7 +43,7 @@ class name_t : public node_factory<dynamic_t> {
 
     auto
     children() const -> boost::optional<std::size_t> override {
-        return 0;
+        return 0ul;
     }
 
     auto
@@ -63,7 +63,7 @@ class type_t : public node_factory<dynamic_t> {
 
     auto
     children() const -> boost::optional<std::size_t> override {
-        return 0;
+        return 0ul;
     }
 
     auto
@@ -84,7 +84,7 @@ public:
 
     auto
     children() const -> boost::optional<std::size_t> override {
-        return 1;
+        return 1ul;
     }
 
     auto


### PR DESCRIPTION
stupid boost::optional complains about 0. I have no idea why, but this patch fixes it.
Note changelog commit, so don't squash PR