### PR TITLE
Minor metrics updates

### DIFF
--- a/metrics/src/service/metrics.cpp
+++ b/metrics/src/service/metrics.cpp
@@ -62,11 +62,11 @@ metrics_t::metrics_t(context_t& context,
     // make_type(out_type);
 
     const auto out_type = std::string("json");
-    const auto filter_ast = args.as_object().at("filter_ast", dynamic_t::null );
+    const auto filter_ast = args.as_object().at("filter_ast", dynamic_t::null);
 
     for(auto& sender_name: sender_names) {
         api::sender_t::data_provider_ptr provider(new api::sender_t::function_data_provider_t([=]() {
-            return metrics( out_type, filter_ast);
+            return metrics(out_type, filter_ast);
         }));
         senders.push_back(api::sender(context, asio, sender_name.as_string(), std::move(provider)));
     }

--- a/metrics/src/service/metrics.cpp
+++ b/metrics/src/service/metrics.cpp
@@ -55,9 +55,18 @@ metrics_t::metrics_t(context_t& context,
 
     auto sender_names = args.as_object().at("senders", dynamic_t::empty_array).as_array();
 
+    // TODO: should we provide an opportunity to select output type to the user?
+    // const auto out_type = args.as_object().at("output_type", "json").as_string();
+    //
+    // throw (fail) early in this::ctor on incorrect user provided type
+    // make_type(out_type);
+
+    const auto out_type = std::string("json");
+    const auto filter_ast = args.as_object().at("filter_ast", dynamic_t::null );
+
     for(auto& sender_name: sender_names) {
         api::sender_t::data_provider_ptr provider(new api::sender_t::function_data_provider_t([=]() {
-            return metrics({}, {});
+            return metrics( out_type, filter_ast);
         }));
         senders.push_back(api::sender(context, asio, sender_name.as_string(), std::move(provider)));
     }


### PR DESCRIPTION
## Various updates to metrics plugin.

To be done: 
1. Sending metrics to backends in heirarchical JSON instead of plain, proposed `.` as commonly used field separator, e.g.: 

Plain view:
```json
{ 
    "storage.connections.accepted": 0, 
    "storage.connections.rejected": 0
}
```
Hierarchical view:
```json
{
    "storage": {
        "connections": {
            "accepted": 0, 
            "rejected": 0
        }
    }
}
```
2. Set filter to metrics sender in cocaine configuration file. AST format should be supported, but MQL support is probably desirable. For now filters are supported on per metrics conf. basis, but possibility of implementing separate filters section in conf. file is discussable.

Filter conf. example:
Source query defined in MQL terms:
```
contains(name(), storage) && type() == counter
```
Resulting record in `cocaine-runtime` config (`filter_ast` field):
```json
{
"metrics": {
  "type": "metrics",
  "args" : {
    "senders" : [ "pg" ],
    "output_type" : "plain",
    "filter_ast" : {
      "and" : [
      {
        "contains" : [
          { "name" : [] },
          { "const" : [ "storage" ]  }
        ]
      },
      {
        "eq" : [
          { "type" : [] },
          { "const" : [ "counter" ] }
        ]
      }
      ]
    }
  }
}
}
```



