### PR TITLE
fix: prevent crash on start apps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+cocaine-plugins (0.12.11.0-alpha14) unstable; urgency=low
+
+  * Fixed: prevent crash on start apps.
+    This commit fixes a bug where Node service trying to start an
+    application with non-existent manifest/profile, which led to exception
+    raising. If the machine isn’t fast enough to spawn a thread it results
+    in segmentation fault or other random memory corruption bugs.
+
+ -- Evgeny Safronov <division494@gmail.com>  Tue, 17 Jan 2017 12:25:10 +0300
+
 cocaine-plugins (0.12.11.0-alpha13) unstable; urgency=low
 
   * Fixed: memory corruption while collecting queue depth EWMA.

--- a/node/include/cocaine/service/node/app.hpp
+++ b/node/include/cocaine/service/node/app.hpp
@@ -25,7 +25,7 @@ class app_t {
 private:
     std::shared_ptr<asio::io_service> loop;
     std::unique_ptr<asio::io_service::work> work;
-    boost::thread thread;
+    std::unique_ptr<boost::thread> thread;
     std::shared_ptr<app_state_t> state;
 
 public:


### PR DESCRIPTION
This PR fixes a bug where Node service trying to start an
application with non-existent manifest/profile, which led to exception
raising. If the machine isn’t fast enough to spawn a thread it results
in segmentation fault or other random memory corruption bugs.