### PR TITLE
Concurrency metrics for slave

### DIFF
--- a/node/include/cocaine/detail/service/node/slave/machine.hpp
+++ b/node/include/cocaine/detail/service/node/slave/machine.hpp
@@ -118,28 +118,8 @@ private:
 
     typedef metrics::usts::ewma_t ewma_type;
 
-    struct metrics_data_t {
-
-        metrics_data_t();
-
-        void
-        update_load(const double &v) {
-            concurrency->add(v);
-        }
-
-        double
-        get_load() const {
-            return concurrency->get();
-        }
-
-        ewma_type &
-        ewma() {
-            return *concurrency;
-        }
-
-    private:
-      std::unique_ptr<ewma_type> concurrency;
-
+    struct {
+        std::unique_ptr<ewma_type> load;
     } metrics_data;
 
 public:

--- a/node/include/cocaine/detail/service/node/slave/machine.hpp
+++ b/node/include/cocaine/detail/service/node/slave/machine.hpp
@@ -120,22 +120,22 @@ private:
 
     struct metrics_data_t {
 
-      metrics_data_t();
+        metrics_data_t();
 
-      void
-      update_concurrency(const double &v) {
-        concurrency->add(v);
-      }
+        void
+        update_load(const double &v) {
+            concurrency->add(v);
+        }
 
-      double
-      get_concurrency() const {
-        return concurrency->get();
-      }
+        double
+        get_load() const {
+            return concurrency->get();
+        }
 
-      ewma_type &
-      get_ewma_ref() {
-        return *concurrency;
-      }
+        ewma_type &
+        ewma() {
+            return *concurrency;
+        }
 
     private:
       std::unique_ptr<ewma_type> concurrency;
@@ -216,7 +216,7 @@ private:
     dump();
 
     ewma_type &
-    concurrency();
+    load_metric();
 };
 
 }  // namespace slave

--- a/node/include/cocaine/detail/service/node/slave/machine.hpp
+++ b/node/include/cocaine/detail/service/node/slave/machine.hpp
@@ -215,7 +215,7 @@ private:
     void
     dump();
 
-    ewma_type &
+    ewma_type&
     load_metric();
 };
 

--- a/node/include/cocaine/detail/service/node/slave/machine.hpp
+++ b/node/include/cocaine/detail/service/node/slave/machine.hpp
@@ -194,9 +194,6 @@ private:
 
     void
     dump();
-
-    ewma_type&
-    load_metric();
 };
 
 }  // namespace slave

--- a/node/include/cocaine/detail/service/node/slave/machine.hpp
+++ b/node/include/cocaine/detail/service/node/slave/machine.hpp
@@ -109,7 +109,7 @@ private:
 
         metrics::shared_metric<metrics::gauge<std::string>> state;
         metrics::shared_metric<metrics::gauge<std::uint64_t>> uptime;
-        metrics::shared_metric<metrics::gauge<double>> concurrency;
+        metrics::shared_metric<metrics::gauge<double>> load;
 
         metrics_t(context_t& context, std::shared_ptr<machine_t> parent);
     };

--- a/node/src/node/slave/machine.cpp
+++ b/node/src/node/slave/machine.cpp
@@ -60,8 +60,8 @@ machine_t::metrics_t::metrics_t(context_t& context, std::shared_ptr<machine_t> p
     })),
     load(context.metrics_hub().register_gauge<double>(format("{}.load", prefix), {}, [=] {
         return parent->data.channels.apply( [&](channels_map_t& channels) {
-            parent->load_metric().add(channels.size());
-            return parent->load_metric().get();
+            parent->metrics_data.load->add(channels.size());
+            return parent->metrics_data.load->get();
         });
     }))
 {}
@@ -450,11 +450,6 @@ machine_t::dump() {
             COCAINE_LOG_WARNING(self->log, "slave is unable to save the crashlog: {}", e.what());
         }
     });
-}
-
-machine_t::ewma_type&
-machine_t::load_metric() {
-    return *metrics_data.load;
 }
 
 }  // namespace slave

--- a/node/src/node/slave/machine.cpp
+++ b/node/src/node/slave/machine.cpp
@@ -442,7 +442,7 @@ machine_t::dump() {
     });
 }
 
-machine_t::ewma_type &
+machine_t::ewma_type&
 machine_t::load_metric() {
     return metrics_data.ewma();
 }

--- a/node/src/node/slave/machine.cpp
+++ b/node/src/node/slave/machine.cpp
@@ -58,7 +58,7 @@ machine_t::metrics_t::metrics_t(context_t& context, std::shared_ptr<machine_t> p
     uptime(context.metrics_hub().register_gauge<std::uint64_t>(format("{}.uptime", prefix), {}, [=] {
         return parent->uptime().count();
     })),
-    concurrency(context.metrics_hub().register_gauge<double>(format("{}.concurrency", prefix), {}, [=] {
+    load(context.metrics_hub().register_gauge<double>(format("{}.load", prefix), {}, [=] {
       parent->load_metric().add(parent->load());
       return parent->load_metric().get();
     }))


### PR DESCRIPTION
Add integral exponential weighted metric for moving average (EWMA) in addition to instant _load_  parameter into slave internals: _machine_t_ class.

Sufficient time interval for EWMA could be chosen later and should be based on tests outcome, for now it is equal to 10 seconds.

Note: not tested yet, committed for early review.