### PR TITLE
Exponentially decaying reservoir histograms in node service

### DIFF
--- a/metrics/src/service/metrics/visitor/dendroid.hpp
+++ b/metrics/src/service/metrics/visitor/dendroid.hpp
@@ -4,6 +4,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 #include <metrics/accumulator/sliding/window.hpp>
+#include <metrics/accumulator/decaying/exponentially.hpp>
 #include <metrics/accumulator/snapshot/uniform.hpp>
 #include <metrics/meter.hpp>
 #include <metrics/timer.hpp>
@@ -63,6 +64,10 @@ public:
     }
 
     auto visit(const libmetrics::timer<libmetrics::accumulator::sliding::window_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::timer<libmetrics::accumulator::decaying::exponentially_t>& metric) -> void override {
         do_visit(metric);
     }
 

--- a/metrics/src/service/metrics/visitor/plain.hpp
+++ b/metrics/src/service/metrics/visitor/plain.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <metrics/accumulator/sliding/window.hpp>
+#include <metrics/accumulator/decaying/exponentially.hpp>
 #include <metrics/accumulator/snapshot/uniform.hpp>
 #include <metrics/meter.hpp>
 #include <metrics/timer.hpp>
@@ -52,6 +53,10 @@ public:
     }
 
     auto visit(const libmetrics::timer<libmetrics::accumulator::sliding::window_t>& metric) -> void override {
+        do_visit(metric);
+    }
+
+    auto visit(const libmetrics::timer<libmetrics::accumulator::decaying::exponentially_t>& metric) -> void override {
         do_visit(metric);
     }
 

--- a/node/include/cocaine/detail/service/node/stats.hpp
+++ b/node/include/cocaine/detail/service/node/stats.hpp
@@ -3,7 +3,7 @@
 #include <atomic>
 #include <cstdint>
 
-#include <metrics/accumulator/sliding/window.hpp>
+#include <metrics/accumulator/decaying/exponentially.hpp>
 #include <metrics/meter.hpp>
 #include <metrics/timer.hpp>
 #include <metrics/usts/ewma.hpp>
@@ -36,7 +36,7 @@ struct stats_t {
     metrics::shared_metric<metrics::gauge<double>> queue_depth_gauge;
 
     /// Channel processing time quantiles (summary).
-    metrics::shared_metric<metrics::timer<metrics::accumulator::sliding::window_t>> timer;
+    metrics::shared_metric<metrics::timer<metrics::accumulator::decaying::exponentially_t>> timer;
 
     stats_t(context_t& context, const std::string& name, std::chrono::high_resolution_clock::duration interval);
 };

--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -245,15 +245,9 @@ public:
         result["timings"] = info;
 
         dynamic_t::object_t reversed;
-        const auto& values = snapshot.values();
 
-        const auto find = [&](double ms) -> double {
-            if (values.empty()) {
-                return 0;
-            }
-
-            const auto it = std::lower_bound(values.begin(), values.end(), ms);
-            return 100.00 * std::distance(values.begin(), it) / values.size();
+        const auto find = [&](const double ms) -> double {
+            return 100.0 * snapshot.phi(ms);
         };
 
         reversed["1ms"]    = trunc(find(1e6), 2);

--- a/node/src/node/stats.cpp
+++ b/node/src/node/stats.cpp
@@ -28,7 +28,7 @@ stats_t::stats_t(context_t& context, const std::string& name, std::chrono::high_
             std::bind(&metrics::usts::ewma_t::get, queue_depth)
         )
     ),
-    timer(context.metrics_hub().timer<metrics::accumulator::sliding::window_t>(cocaine::format("{}.timings", name)))
+    timer(context.metrics_hub().timer<metrics::accumulator::decaying::exponentially_t>(cocaine::format("{}.timings", name)))
 {
     queue_depth->add(0);
 }


### PR DESCRIPTION
 * update metrics plugin to be compatible with fresh metrics::visitor_t interface
 * change _sliding window_ based timing histograms to _exponentially decaying reservoir_