### PR TITLE
fix: use protocol extension to properly pass discard of a channel

### DIFF
--- a/vicodyn/include/cocaine/vicodyn/proxy/dispatch.hpp
+++ b/vicodyn/include/cocaine/vicodyn/proxy/dispatch.hpp
@@ -21,6 +21,8 @@ public:
     auto process(const io::decoder_t::message_type& incoming_message, const io::upstream_ptr_t&) const
         -> boost::optional<io::dispatch_ptr_t> override;
 
+    auto discard(const std::error_code& ec) const -> void override;
+
 private:
     std::shared_ptr<stream_t> proxy_stream;
     mutable std::string full_name;

--- a/vicodyn/include/cocaine/vicodyn/queue/invocation.hpp
+++ b/vicodyn/include/cocaine/vicodyn/queue/invocation.hpp
@@ -27,10 +27,6 @@ public:
 
     auto connected() -> bool;
 
-    ~invocation_t() {
-            VICODYN_DEBUG("queue dtor, use count - {}", m_session->use_count());
-    }
-
 private:
     struct operation_t {
         // msgpack object

--- a/vicodyn/include/cocaine/vicodyn/stream.hpp
+++ b/vicodyn/include/cocaine/vicodyn/stream.hpp
@@ -14,7 +14,11 @@ namespace vicodyn {
 
 class stream_t {
 public:
-    stream_t();
+    enum class direction_t {
+        forward,
+        backward
+    };
+    stream_t(direction_t);
     stream_t(const stream_t&) = delete;
     stream_t& operator=(const stream_t&) = delete;
     stream_t(stream_t&&) = default;
@@ -24,6 +28,8 @@ public:
     auto attach(std::shared_ptr<session_t> session) -> void;
 
     auto append(const msgpack::object& message, uint64_t event_id, hpack::header_storage_t headers) -> void;
+
+    auto discard(std::error_code) -> void;
 
 private:
     struct operation_t {
@@ -42,6 +48,12 @@ private:
         // message headers
         hpack::header_storage_t headers;
     };
+
+    auto try_discard() -> void;
+
+    synchronized<void> attach_mutex;
+    direction_t direction;
+    boost::optional<std::error_code> discard_code;
 
     // Operation log.
     std::vector<operation_t> operations;

--- a/vicodyn/src/vicodyn/peer.cpp
+++ b/vicodyn/src/vicodyn/peer.cpp
@@ -20,7 +20,6 @@ namespace cocaine {
 namespace vicodyn {
 
 peer_t::~peer_t(){
-    VICODYN_DEBUG("peer dtor");
 }
 
 peer_t::peer_t(context_t& _context, asio::io_service& _loop) :

--- a/vicodyn/src/vicodyn/proxy.cpp
+++ b/vicodyn/src/vicodyn/proxy.cpp
@@ -56,7 +56,7 @@ proxy_t::process(const io::decoder_t::message_type& incoming_message, const io::
         COCAINE_LOG_ERROR(logger, msg);
         throw error_t(error::slot_not_found, msg);
     }
-    stream_ptr_t backward_stream = std::make_shared<stream_t>();
+    stream_ptr_t backward_stream = std::make_shared<stream_t>(stream_t::direction_t::backward);
     backward_stream->attach(std::move(raw_backward_stream));
     auto forward_stream = pool->invoke(incoming_message, *backward_protocol, std::move(backward_stream));
 

--- a/vicodyn/src/vicodyn/proxy/dispatch.cpp
+++ b/vicodyn/src/vicodyn/proxy/dispatch.cpp
@@ -75,6 +75,10 @@ auto dispatch_t::process(const io::decoder_t::message_type& incoming_message, co
     return boost::optional<io::dispatch_ptr_t>(shared_from_this());
 }
 
+auto dispatch_t::discard(const std::error_code& ec) const -> void {
+    proxy_stream->discard(ec);
+}
+
 }
 }
 } // namesapce cocaine

--- a/vicodyn/src/vicodyn/queue/invocation.cpp
+++ b/vicodyn/src/vicodyn/queue/invocation.cpp
@@ -42,7 +42,7 @@ auto invocation_t::append(const msgpack::object& message,
                           const io::graph_node_t& incoming_protocol,
                           stream_ptr_t backward_stream) -> std::shared_ptr<stream_t>
 {
-    auto forward_stream = std::make_shared<stream_t>();
+    auto forward_stream = std::make_shared<stream_t>(stream_t::direction_t::forward);
     m_session.apply([&](std::shared_ptr<session_t>& session) mutable {
         if(!session) {
             m_operations.resize(m_operations.size()+1);

--- a/vicodyn/src/vicodyn/stream.cpp
+++ b/vicodyn/src/vicodyn/stream.cpp
@@ -1,13 +1,34 @@
 #include "cocaine/vicodyn/stream.hpp"
 
+#include "cocaine/vicodyn/session.hpp"
+
+#include <cocaine/idl/primitive.hpp>
 #include <cocaine/rpc/asio/encoder.hpp>
 #include <cocaine/rpc/asio/decoder.hpp>
 #include <cocaine/rpc/upstream.hpp>
+#include <cocaine/rpc/dispatch.hpp>
 
 namespace cocaine {
 namespace vicodyn {
 
 namespace {
+
+struct discard_dispatch_t: public dispatch<io::option_of<>::tag> {
+    discard_dispatch_t(std::shared_ptr<session_t> _session) :
+            dispatch<io::option_of<>::tag>(cocaine::format("{}/discarder", _session->get().name())),
+            session(std::move(_session))
+    {
+        on<io::protocol<io::option_of<>::tag>::scope::value>([](){
+            VICODYN_DEBUG("channel sucessfully discarded");
+        });
+        on<io::protocol<io::option_of<>::tag>::scope::error>([&](const std::error_code& ec, const std::string& msg){
+            VICODYN_DEBUG("can not discard channel, terminating session - ({}){}", ec.value(), msg);
+            session->get().detach(ec);
+        });
+    }
+
+    std::shared_ptr<session_t> session;
+};
 
 struct partially_encoded_t {
     partially_encoded_t(const msgpack::object& message,
@@ -28,7 +49,6 @@ struct partially_encoded_t {
 
     io::aux::encoded_message_t
     operator()(io::encoder_t& encoder) {
-        VICODYN_DEBUG("partially encoded called");
         encoder.pack_headers(packer, headers);
         return std::move(*encoded_message);
     }
@@ -41,48 +61,83 @@ struct partially_encoded_t {
 
 }
 
-stream_t::stream_t() { }
+stream_t::stream_t(direction_t _direction) : direction(_direction){ }
 
 auto stream_t::append(const msgpack::object& message, uint64_t event_id, hpack::header_storage_t headers) -> void {
-    //TODO: synchronization
-    if(!wrapped_stream) {
-        operations.resize(operations.size() + 1);
-        auto& operation = operations.back();
-        operation.event_id = event_id;
-        operation.headers = std::move(headers);
-        operation.zone.reset(new msgpack::zone);
+    //TODO: can we decrease time under mutex?
+    attach_mutex.apply([&]{
+        if(!wrapped_stream) {
+            operations.resize(operations.size() + 1);
+            auto& operation = operations.back();
+            operation.event_id = event_id;
+            operation.headers = std::move(headers);
+            operation.zone.reset(new msgpack::zone);
 
-        msgpack::packer<io::aux::encoded_message_t> packer(operation.encoded_message);
-        packer << message;
-        size_t offset;
-        msgpack::unpack(operation.encoded_message.data(),
-                        operation.encoded_message.size(),
-                        &offset,
-                        operation.zone.get(),
-                        &operation.data);
-    } else {
-        partially_encoded_t partially_encoded(message, event_id, std::move(headers), wrapped_stream->channel_id());
-        io::aux::unbound_message_t unbound_message(std::move(partially_encoded));
-        VICODYN_DEBUG("sending to stream with channel {}", wrapped_stream->channel_id());
-        wrapped_stream->send(std::move(unbound_message));
-    }
+            msgpack::packer<io::aux::encoded_message_t> packer(operation.encoded_message);
+            packer << message;
+            size_t offset;
+            msgpack::unpack(operation.encoded_message.data(),
+                            operation.encoded_message.size(),
+                            &offset,
+                            operation.zone.get(),
+                            &operation.data);
+        } else {
+            partially_encoded_t partially_encoded(message, event_id, std::move(headers), wrapped_stream->channel_id());
+            io::aux::unbound_message_t unbound_message(std::move(partially_encoded));
+            wrapped_stream->send(std::move(unbound_message));
+        }
+    });
 }
 
 auto stream_t::attach(io::upstream_ptr_t stream) -> void {
-    wrapped_stream = std::move(stream);
-    if(!operations.empty()) {
-        for (auto& op : operations) {
-            partially_encoded_t partially_encoded(op.data, op.event_id, std::move(op.headers), wrapped_stream->channel_id());
-            io::aux::unbound_message_t unbound_message(std::move(partially_encoded));
-            VICODYN_DEBUG("sending to stream with channel {}", wrapped_stream->channel_id());
-            wrapped_stream->send(std::move(unbound_message));
+    attach_mutex.apply([&]{
+        wrapped_stream = std::move(stream);
+        if(!operations.empty()) {
+            for (auto& op : operations) {
+                partially_encoded_t partially_encoded(op.data, op.event_id, std::move(op.headers), wrapped_stream->channel_id());
+                io::aux::unbound_message_t unbound_message(std::move(partially_encoded));
+                wrapped_stream->send(std::move(unbound_message));
+            }
+            operations.clear();
         }
-        operations.clear();
-    }
+        try_discard();
+    });
+
 }
 
 auto stream_t::attach(std::shared_ptr<session_t> _session) -> void {
-    session = _session;
+    attach_mutex.apply([&]{
+        session = _session;
+        try_discard();
+    });
+}
+
+auto stream_t::discard(std::error_code ec) -> void {
+    VICODYN_DEBUG("discard called");
+    attach_mutex.apply([&]{
+        discard_code = std::move(ec);
+        try_discard();
+    });
+}
+
+auto stream_t::try_discard() -> void {
+    if(!discard_code) {
+        return;
+    }
+
+    if(direction == direction_t::forward && session) {
+        auto upstream = session->get().fork(std::make_shared<discard_dispatch_t>(session));
+        try {
+            upstream->send<io::control::revoke>(wrapped_stream->channel_id(), *discard_code);
+        } catch(...) {
+            // session is gone - no need to revoke channel
+        }
+        discard_code = boost::none;
+    }
+    if(direction == direction_t::backward && wrapped_stream) {
+        wrapped_stream->detach_session(*discard_code);
+        discard_code = boost::none;
+    }
 }
 
 } // namespace vicodyn


### PR DESCRIPTION
This uses protocol extension from https://github.com/3Hren/cocaine-core/pull/152 and allows vicodyn to discard pending channels on client disconnection.