### PR TITLE
Prevent sigsegv on long term spools

### DIFF
--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -581,7 +581,7 @@ private:
                 // throw?
                 return;
             }
-            COCAINE_LOG_ERROR(parent.log, "unable to spool app, [{}] {} - {}", ec.value(), ec.message(), reason);
+            COCAINE_LOG_ERROR(p->log, "unable to spool app, [{}] {} - {}", ec.value(), ec.message(), reason);
             // Dispatch the completion handler to be sure it will be called in a I/O thread to
             // avoid possible deadlocks.
             p->loop->dispatch(std::bind(&app_state_t::cancel, p, ec));

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -601,7 +601,7 @@ private:
         }
 
         spool_handle_t(const std::shared_ptr<app_state_t>& _parent) :
-            parent(move(_parent))
+            parent(_parent)
         {}
 
         // It seems that spool_handle_t could survive somewhere inside isolation

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -477,7 +477,8 @@ private:
 } // namespace state
 
 class cocaine::service::node::app_state_t
-    : public std::enable_shared_from_this<cocaine::service::node::app_state_t> {
+    : public std::enable_shared_from_this<cocaine::service::node::app_state_t>
+{
 
     const std::unique_ptr<logging::logger_t> log;
 
@@ -577,8 +578,6 @@ private:
         on_abort(const std::error_code& ec, const std::string& reason) {
             const auto p = parent.lock();
             if (!p) {
-                // TODO: should we inform RT (or logger) that there was nothing to abort?
-                // throw?
                 return;
             }
             COCAINE_LOG_ERROR(p->log, "unable to spool app, [{}] {} - {}", ec.value(), ec.message(), reason);
@@ -594,8 +593,6 @@ private:
         on_ready() {
             const auto p = parent.lock();
             if (!p) {
-                // TODO: should we inform RT (or logger) that application was never cast alive?
-                // Throw?
                 return;
             }
 
@@ -603,7 +600,7 @@ private:
             p->loop->dispatch(std::bind(&app_state_t::publish, p));
         }
 
-        spool_handle_t(std::shared_ptr<app_state_t> _parent) :
+        spool_handle_t(const std::shared_ptr<app_state_t>& _parent) :
             parent(move(_parent))
         {}
 


### PR DESCRIPTION
Prevent app's eager riding on the waves of memory In case of application stoppage while long term _spooling_ is in progress.

Long _spawn_ case should be also considered, but seems not affected.

@antmat, @3Hren PTAL.