### PR TITLE
refactor: drop tagged requests

### DIFF
--- a/node/include/cocaine/detail/service/node/engine.hpp
+++ b/node/include/cocaine/detail/service/node/engine.hpp
@@ -115,9 +115,8 @@ public:
     ///
     /// \param downstream represents the [Client <- Worker] stream.
     /// \param event an invocation event.
-    /// \param id represents slave id to be enqueued (may be none, which means any slave).
-    auto enqueue(upstream<io::stream_of<std::string>::tag> downstream, event_t event,
-                 boost::optional<id_t> id) -> std::shared_ptr<client_rpc_dispatch_t>;
+    auto enqueue(upstream<io::stream_of<std::string>::tag> downstream, event_t event)
+        -> std::shared_ptr<client_rpc_dispatch_t>;
 
     /// Enqueues the new event into the most appropriate slave.
     ///
@@ -127,10 +126,9 @@ public:
     /// \param rx a receiver stream which methods will be called when the appropriate messages
     ///     received.
     /// \param event an invocation event.
-    /// \param id represents slave id to be enqueued (may be none, which means any slave).
     /// \return a tx stream.
-    auto enqueue(std::shared_ptr<api::stream_t> rx, event_t event, boost::optional<id_t> id) ->
-        std::shared_ptr<api::stream_t>;
+    auto enqueue(std::shared_ptr<api::stream_t> rx, event_t event)
+        -> std::shared_ptr<api::stream_t>;
 
     /// Tries to keep alive at least `count` workers no matter what.
     ///

--- a/node/include/cocaine/detail/service/node/slave/load.hpp
+++ b/node/include/cocaine/detail/service/node/slave/load.hpp
@@ -21,9 +21,6 @@ struct load_t {
     /// Associcated trace.
     trace_t trace;
 
-    /// Optional slave id to be able to route events into the same slaves.
-    boost::optional<id_t> id;
-
     /// An TX dispatch.
     std::shared_ptr<client_rpc_dispatch_t> dispatch;
 

--- a/node/include/cocaine/idl/node.hpp
+++ b/node/include/cocaine/idl/node.hpp
@@ -51,7 +51,9 @@ struct enqueue {
      /* Event name. This name is intentionally dynamic so that the underlying application can
         do whatever it wants using these event names, for example handle every possible one. */
         std::string,
-     /* Tag. Event can be enqueued to a specific worker with some user-defined name. */
+     /* Tag. Event can be enqueued to a specific worker with some user-defined name.
+
+        DEPRECATED: no longer used. */
         optional<std::string>
     >::type argument_type;
 

--- a/node/include/cocaine/service/node/overseer.hpp
+++ b/node/include/cocaine/service/node/overseer.hpp
@@ -65,13 +65,11 @@ public:
     ///
     /// \param downstream represents the [Client <- Worker] stream.
     /// \param event an invocation event.
-    /// \param id represents slave id to be enqueued (may be none, which means any slave).
     ///
     /// \return the dispatch object, which is ready for processing the appropriate protocol
     ///     messages.
     auto enqueue(upstream<io::stream_of<std::string>::tag> downstream,
-                 app::event_t event,
-                 boost::optional<slave::id_t> id) -> std::shared_ptr<client_rpc_dispatch_t>;
+                 app::event_t event) -> std::shared_ptr<client_rpc_dispatch_t>;
 
     /// Enqueues the new event into the most appropriate slave.
     ///
@@ -81,12 +79,10 @@ public:
     /// \param rx a receiver stream which methods will be called when the appropriate messages
     ///     received.
     /// \param event an invocation event.
-    /// \param id represents slave id to be enqueued (may be none, which means any slave).
     ///
     /// \return a tx stream.
     auto enqueue(std::shared_ptr<api::stream_t> rx,
-                 app::event_t event,
-                 boost::optional<slave::id_t> id) -> std::shared_ptr<api::stream_t>;
+                 app::event_t event) -> std::shared_ptr<api::stream_t>;
 
     /// Tries to keep alive at least `count` workers no matter what.
     ///

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -187,8 +187,7 @@ private:
                std::tuple<std::string, std::string> args)
     {
         std::string event;
-        std::string id;
-        std::tie(event, id) = args;
+        std::tie(event, std::ignore) = args;
 
         COCAINE_LOG_DEBUG(log, "processing enqueue '{}' event", event);
 
@@ -196,11 +195,7 @@ private:
 
         try {
             if (auto overseer = this->overseer.lock()) {
-                if (id.empty()) {
-                    return overseer->o->enqueue(upstream, {event, hpack::header_storage_t(headers)}, boost::none);
-                } else {
-                    return overseer->o->enqueue(upstream, {event, hpack::header_storage_t(headers)}, service::node::slave::id_t(id));
-                }
+                return overseer->o->enqueue(upstream, {event, hpack::header_storage_t(headers)});
             } else {
                 // We shouldn't close the connection here, because there possibly can be events
                 // processing.

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -56,15 +56,16 @@ auto overseer_t::control_population(int count) -> void {
     return engine->control_population(count);
 }
 
-auto overseer_t::enqueue(upstream<io::stream_of<std::string>::tag> downstream, app::event_t event,
-                         boost::optional<slave::id_t> id)
-    -> std::shared_ptr<client_rpc_dispatch_t> {
-    return engine->enqueue(std::move(downstream), std::move(event), std::move(id));
+auto overseer_t::enqueue(upstream<io::stream_of<std::string>::tag> downstream, app::event_t event)
+    -> std::shared_ptr<client_rpc_dispatch_t>
+{
+    return engine->enqueue(std::move(downstream), std::move(event));
 }
 
-auto overseer_t::enqueue(std::shared_ptr<api::stream_t> rx, app::event_t event,
-                         boost::optional<slave::id_t> id) -> std::shared_ptr<api::stream_t> {
-    return engine->enqueue(std::move(rx), std::move(event), std::move(id));
+auto overseer_t::enqueue(std::shared_ptr<api::stream_t> rx, app::event_t event)
+    -> std::shared_ptr<api::stream_t>
+{
+    return engine->enqueue(std::move(rx), std::move(event));
 }
 
 auto overseer_t::prototype() -> io::dispatch_ptr_t {


### PR DESCRIPTION
It may be considered as dead code elimination, since no one uses them
for now.

Less code - less bugs, wow.