### PR TITLE
Isolation daemon's workers metrics

### DIFF
--- a/docker/isolate.cpp
+++ b/docker/isolate.cpp
@@ -285,3 +285,8 @@ docker_t::spawn(const std::string& path,
         throw cocaine::error_t("{}", e.what());
     }
 }
+
+void
+docker_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t>) const
+{}
+

--- a/docker/isolate.cpp
+++ b/docker/isolate.cpp
@@ -287,6 +287,7 @@ docker_t::spawn(const std::string& path,
 }
 
 void
-docker_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t>) const
-{}
-
+docker_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t> handle) const
+{
+    return handle->on_data({});
+}

--- a/docker/isolate.hpp
+++ b/docker/isolate.hpp
@@ -53,7 +53,7 @@ public:
 
     virtual
     void
-    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const override;
+    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const;
 
 private:
     context_t& m_context;

--- a/docker/isolate.hpp
+++ b/docker/isolate.hpp
@@ -42,7 +42,7 @@ public:
 
     virtual
     std::unique_ptr<api::cancellation_t>
-    spool(std::shared_ptr<api::spool_handle_base_t> handler);
+    spool(std::shared_ptr<api::spool_handle_base_t> handle);
 
     virtual
     std::unique_ptr<api::cancellation_t>
@@ -50,6 +50,10 @@ public:
           const api::args_t& args,
           const api::env_t& environment,
           std::shared_ptr<api::spawn_handle_base_t> handle);
+
+    virtual
+    void
+    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const override;
 
 private:
     context_t& m_context;

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(${PLUGIN_NAME} SHARED
     src/node/dispatch/client.cpp
     src/node/dispatch/worker.cpp
     src/node/engine.cpp
+    src/node/isometrics.cpp
     src/node/error.cpp
     src/node/manifest.cpp
     src/node/overseer.cpp

--- a/node/include/cocaine/api/isolate.hpp
+++ b/node/include/cocaine/api/isolate.hpp
@@ -91,6 +91,19 @@ struct spawn_handle_base_t {
     on_data(const std::string& data) = 0;
 };
 
+struct metrics_handle_base_t {
+    virtual
+    ~metrics_handle_base_t() {}
+
+    virtual
+    void
+    on_data(const dynamic_t& data) = 0;
+
+    virtual
+    void
+    on_error(const std::error_code& ec, const std::string& msg) = 0;
+};
+
 typedef std::map<std::string, std::string> args_t;
 typedef std::map<std::string, std::string> env_t;
 
@@ -110,6 +123,10 @@ struct isolate_t {
     std::unique_ptr<cancellation_t>
     spawn(const std::string& path, const args_t& args, const env_t& environment,
                 std::shared_ptr<api::spawn_handle_base_t> handle) = 0;
+
+    virtual
+    void
+    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const = 0;
 
     asio::io_service&
     get_io_service() {

--- a/node/include/cocaine/api/isolate.hpp
+++ b/node/include/cocaine/api/isolate.hpp
@@ -63,7 +63,7 @@ struct cancellation_wrapper :
 
 struct spool_handle_base_t {
     virtual
-    ~spool_handle_base_t() {}
+    ~spool_handle_base_t() = default;
 
     virtual
     void
@@ -76,7 +76,7 @@ struct spool_handle_base_t {
 
 struct spawn_handle_base_t {
     virtual
-    ~spawn_handle_base_t() {}
+    ~spawn_handle_base_t() = default;
 
     virtual
     void
@@ -93,7 +93,7 @@ struct spawn_handle_base_t {
 
 struct metrics_handle_base_t {
     virtual
-    ~metrics_handle_base_t() {}
+    ~metrics_handle_base_t() = default;
 
     virtual
     void
@@ -111,9 +111,7 @@ struct isolate_t {
     typedef isolate_t category_type;
 
     virtual
-    ~isolate_t() {
-        // Empty.
-    }
+    ~isolate_t() = default;
 
     virtual
     std::unique_ptr<cancellation_t>
@@ -122,11 +120,12 @@ struct isolate_t {
     virtual
     std::unique_ptr<cancellation_t>
     spawn(const std::string& path, const args_t& args, const env_t& environment,
-                std::shared_ptr<api::spawn_handle_base_t> handle) = 0;
+                std::shared_ptr<api::spawn_handle_base_t> handler) = 0;
 
     virtual
     void
-    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const = 0;
+    metrics(const dynamic_t& query,
+        std::shared_ptr<api::metrics_handle_base_t> handle) const = 0;
 
     asio::io_service&
     get_io_service() {

--- a/node/include/cocaine/api/isolate.hpp
+++ b/node/include/cocaine/api/isolate.hpp
@@ -125,7 +125,7 @@ struct isolate_t {
     virtual
     void
     metrics(const dynamic_t& query,
-        std::shared_ptr<api::metrics_handle_base_t> handle) const = 0;
+        std::shared_ptr<api::metrics_handle_base_t> handler) const = 0;
 
     asio::io_service&
     get_io_service() {

--- a/node/include/cocaine/detail/isolate/external.hpp
+++ b/node/include/cocaine/detail/isolate/external.hpp
@@ -45,6 +45,10 @@ public:
                 const api::env_t& environment,
                 std::shared_ptr<api::spawn_handle_base_t>);
 
+    virtual
+    void
+    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const override;
+
     struct inner_t;
 
 private:
@@ -53,6 +57,5 @@ private:
 };
 
 }} // namespace cocaine::isolate
-
 
 #endif

--- a/node/include/cocaine/detail/isolate/process.hpp
+++ b/node/include/cocaine/detail/isolate/process.hpp
@@ -58,6 +58,10 @@ public:
     std::unique_ptr<api::cancellation_t>
     spawn(const std::string& path, const api::args_t& args, const api::env_t& environment,
                 std::shared_ptr<api::spawn_handle_base_t>);
+
+    virtual
+    void
+    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const override;
 };
 
 }} // namespace cocaine::isolate

--- a/node/include/cocaine/detail/service/node/forwards.hpp
+++ b/node/include/cocaine/detail/service/node/forwards.hpp
@@ -14,6 +14,7 @@ namespace api {
 struct cancellation_t;
 struct spool_handle_base_t;
 struct spawn_handle_base_t;
+struct metrics_handle_base_t;
 
 class stream_t;
 

--- a/node/include/cocaine/detail/service/node/isometrics.hpp
+++ b/node/include/cocaine/detail/service/node/isometrics.hpp
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <blackhole/logger.hpp>
+#include <blackhole/scope/holder.hpp>
+
+#include <cocaine/format.hpp>
+#include <cocaine/context.hpp>
+#include <cocaine/logging.hpp>
+#include <cocaine/repository.hpp>
+
+#include "cocaine/service/node/manifest.hpp"
+#include "cocaine/service/node/profile.hpp"
+
+#include "cocaine/detail/service/node/engine.hpp"
+
+#include <metrics/factory.hpp>
+#include <metrics/registry.hpp>
+
+#include "node/pool_observer.hpp"
+
+namespace cocaine {
+namespace detail {
+namespace service {
+namespace node {
+
+struct worker_metrics_t {
+    // running times
+    metrics::shared_metric<std::atomic<std::uint64_t>> uptime;
+    metrics::shared_metric<std::atomic<std::uint64_t>> user_time;
+    metrics::shared_metric<std::atomic<std::uint64_t>> sys_time;
+
+    // memory usage (in bytes)
+    metrics::shared_metric<std::atomic<std::uint64_t>> vms;
+    metrics::shared_metric<std::atomic<std::uint64_t>> rss;
+
+    // threads stats
+    metrics::shared_metric<std::atomic<std::uint64_t>> threads_count;
+
+    //
+    // TODO: more to add
+    //
+
+    worker_metrics_t(context_t& ctx, const std::string &app_name, const std::string &id);
+};
+
+// TODO: hardly WIP, move those garbage to .cpp file,
+struct metrics_resp_proc_t {
+    metrics_resp_proc_t(dynamic_t& response) :
+        response(response),
+        processed{false}
+    {}
+
+    auto
+    process() -> void {
+        // TODO
+        processed = true;
+    }
+
+    auto
+    is_processed() const -> bool {
+            return processed;
+    }
+
+    auto
+    errors_count() const -> std::size_t {
+        return errors.size();
+    }
+
+    // auto
+    // errors_ref() -> const std::vector<error_t>& {
+    //     return errors;
+    // }
+
+    //
+    // auto
+    // metrics_ref() -> const std::vector<worker_metrics_t>& {
+    //     return wrks_metrics;
+    // }
+
+    struct error_t {
+        int code;
+        std::string msg;
+    };
+
+private:
+    dynamic_t& response;
+    bool processed;
+
+    std::vector<error_t> errors;
+    std::vector<worker_metrics_t> wrks_metrics;
+};
+
+class metrics_retriever_t :
+    public std::enable_shared_from_this<metrics_retriever_t>
+{
+    context_t &context;
+
+    asio::deadline_timer metrics_poll_timer;
+    std::shared_ptr<api::isolate_t> isolate;
+
+    synchronized<engine_t::pool_type> &pool;
+
+    const std::unique_ptr<cocaine::logging::logger_t> log;
+
+    //
+    // Poll intervals could be quite large (should be configurable), so the
+    // Isolation Daemon suppors metrics in memory persistance for dead workers
+    // (at least for 30 seconds) and it is possible to query for workers which
+    // have passed away not too long ago (corpuses are still hot). Their uuids
+    // will be taken and added to request from `purgatory`.
+    //
+    using purgatory_pot_type = std::set<std::string>;
+    synchronized<purgatory_pot_type> purgatory;
+
+    // <uuid, metrics>
+    synchronized<std::unordered_map<std::string, worker_metrics_t>> metrics;
+
+    struct self_metrics_t {
+        metrics::shared_metric<std::atomic<std::uint64_t>> uuid_requested;
+        metrics::shared_metric<std::atomic<std::uint64_t>> uuid_recieved;
+        metrics::shared_metric<std::atomic<std::uint64_t>> receive_errors;
+        metrics::shared_metric<std::atomic<std::uint64_t>> posmortem_queue_size;
+
+        self_metrics_t(context_t &ctx, const std::string &name);
+    } self_metrics;
+
+    std::string app_name;
+
+public:
+
+    metrics_retriever_t(context_t &ctx, const std::string &name, std::shared_ptr<api::isolate_t> isolate, synchronized<engine_t::pool_type> &pool, asio::io_service &loop);
+
+    auto
+    ignite_poll() -> void;
+
+    // should be called on every pool::erase(id) invocation
+    //
+    // usually isolation daemon will hold metrics of despawned workers for some
+    // reasonable period (at least 30 sec), so it is allowed to request metrics
+    // of dead workers on next `poll` invocation.
+    //
+    // TODO: seems that can be called from engine_t (not yet born) pool observers list
+    //
+    // Note: on high despawn rates stat of some unlucky workers will be lost
+    //
+    auto
+    add_post_mortem(const std::string &id) -> void;
+
+private:
+
+    auto
+    poll_metrics(const std::error_code& ec) -> void;
+
+private:
+
+    // TODO: wip, possibility of redesign 
+    struct metrics_handle_t : public api::metrics_handle_base_t
+    {
+        metrics_handle_t(std::shared_ptr<metrics_retriever_t> parent) :
+            parent{parent}
+        {}
+
+        auto
+        on_data(const dynamic_t& data) -> void override;
+
+        auto
+        on_error(const std::error_code&, const std::string& what) -> void override;
+
+        std::shared_ptr<metrics_retriever_t> parent;
+    };
+
+}; // metrics_retriever_t
+
+}  // namespace node
+}  // namespace service
+}  // namespace detail
+}  // namespace cocaine

--- a/node/include/cocaine/detail/service/node/isometrics.hpp
+++ b/node/include/cocaine/detail/service/node/isometrics.hpp
@@ -100,14 +100,12 @@ private:
         metrics::shared_metric<std::atomic<std::uint64_t>> requests_send;
         metrics::shared_metric<std::atomic<std::uint64_t>> receive_errors;
         metrics::shared_metric<std::atomic<std::uint64_t>> posmortem_queue_size;
-
         self_metrics_t(context_t& ctx, const std::string& name);
     } self_metrics;
 
     std::string app_name;
 
     worker_metrics_t app_aggregate_metrics;
-
 public:
 
     metrics_retriever_t(
@@ -126,7 +124,7 @@ public:
         std::shared_ptr<api::isolate_t> isolate,
         synchronized<engine_t::pool_type>& pool,
         asio::io_service& loop,
-        Observers& observers) -> std::shared_ptr<metrics_retriever_t>;
+        synchronized<Observers>& observers) -> std::shared_ptr<metrics_retriever_t>;
 
     auto
     ignite_poll() -> void;
@@ -202,7 +200,7 @@ metrics_retriever_t::make_and_ignite(
     const std::string& name,
     std::shared_ptr<api::isolate_t> isolate,
     synchronized<engine_t::pool_type>& pool,
-    asio::io_service& loop, Observers& observers) -> std::shared_ptr<metrics_retriever_t>
+    asio::io_service& loop, synchronized<Observers>& observers) -> std::shared_ptr<metrics_retriever_t>
 {
     auto retriever = std::make_shared<metrics_retriever_t>(ctx, name, std::move(isolate), pool, loop);
 

--- a/node/include/cocaine/idl/isolate.hpp
+++ b/node/include/cocaine/idl/isolate.hpp
@@ -89,12 +89,14 @@ struct isolate {
         }
 
         typedef boost::mpl::list<
+            // Isolation daemon metrics query, in common cases - list of uuids.
             dynamic_t
         > argument_type;
 
         typedef isolate_tag dispatch_type;
 
         typedef option_of<
+            // Worker metrics grouped by uuids and application name.
             dynamic_t
         >::tag upstream_type;
     };
@@ -124,7 +126,6 @@ struct isolate_spooled {
 
 template<>
 struct protocol<isolate_tag> {
-
     typedef boost::mpl::int_<
         1
     >::type version;

--- a/node/include/cocaine/idl/isolate.hpp
+++ b/node/include/cocaine/idl/isolate.hpp
@@ -35,6 +35,7 @@ struct isolate_spawned_tag;
 struct isolate_spooled_tag;
 
 struct isolate {
+
     struct spool {
         typedef isolate_tag tag;
 
@@ -80,6 +81,21 @@ struct isolate {
         >::tag upstream_type;
     };
 
+    struct metrics {
+        typedef isolate_tag tag;
+
+        static const char* alias() {
+            return "metrics";
+        }
+
+        typedef boost::mpl::list<
+            dynamic_t
+        > argument_type;
+
+        typedef option_of<
+            dynamic_t
+        >::tag upstream_type;
+    };
 };
 
 struct isolate_spawned {
@@ -106,13 +122,15 @@ struct isolate_spooled {
 
 template<>
 struct protocol<isolate_tag> {
+
     typedef boost::mpl::int_<
         1
     >::type version;
 
     typedef mpl::list<
         isolate::spool,
-        isolate::spawn
+        isolate::spawn,
+        isolate::metrics
     > messages;
 
     typedef isolate scope;

--- a/node/include/cocaine/idl/isolate.hpp
+++ b/node/include/cocaine/idl/isolate.hpp
@@ -92,6 +92,8 @@ struct isolate {
             dynamic_t
         > argument_type;
 
+        typedef isolate_tag dispatch_type;
+
         typedef option_of<
             dynamic_t
         >::tag upstream_type;

--- a/node/include/cocaine/service/node/forwards.hpp
+++ b/node/include/cocaine/service/node/forwards.hpp
@@ -12,6 +12,7 @@ namespace detail {
 namespace service {
 namespace node {
 
+class metrics_retriever_t;
 class engine_t;
 
 namespace slave {

--- a/node/include/cocaine/service/node/overseer.hpp
+++ b/node/include/cocaine/service/node/overseer.hpp
@@ -27,7 +27,7 @@ public:
     overseer_t(context_t& context,
                manifest_t manifest,
                profile_t profile,
-               pool_observer& observer,
+               std::shared_ptr<pool_observer> observer,
                std::shared_ptr<asio::io_service> loop);
 
     /// TODO: Docs.

--- a/node/src/isolate/external.cpp
+++ b/node/src/isolate/external.cpp
@@ -96,7 +96,7 @@ struct metrics_dispatch_t :
 {
     typedef io::protocol<io::event_traits<io::isolate::metrics>::upstream_type>::scope protocol;
 
-    metrics_dispatch_t(const std::string &name, std::shared_ptr<api::metrics_handle_base_t> handle)
+    metrics_dispatch_t(const std::string& name, std::shared_ptr<api::metrics_handle_base_t> handle)
         : dispatch(name)
     {
         namespace ph = std::placeholders;
@@ -171,14 +171,14 @@ struct spawn_load_t :
 };
 
 struct metrics_load_t {
-    std::weak_ptr<external_t::inner_t> inner;
+    std::shared_ptr<external_t::inner_t> inner;
     std::shared_ptr<api::metrics_handle_base_t> handle;
 
     dynamic_t query;
 
     synchronized<io::upstream_ptr_t> stream;
 
-    metrics_load_t(std::weak_ptr<external_t::inner_t> _inner,
+    metrics_load_t(std::shared_ptr<external_t::inner_t> _inner,
                    const dynamic_t& _query,
                    std::shared_ptr<api::metrics_handle_base_t> _handle
     ) :
@@ -398,11 +398,7 @@ spawn_load_t::apply() {
 
 void
 metrics_load_t::apply() {
-    auto _inner = inner.lock();
-    if (!_inner) {
-        return;
-    }
-
+    auto _inner = inner;
     stream.apply([&](decltype(stream.unsafe())& stream){
         try {
             stream = _inner->session->fork(std::make_shared<metrics_dispatch_t>("external_metrics/" + _inner->name, handle));

--- a/node/src/isolate/external.cpp
+++ b/node/src/isolate/external.cpp
@@ -489,6 +489,9 @@ external_t::spawn(const std::string& path,
     return std::unique_ptr<api::cancellation_t>(new api::cancellation_wrapper(load));
 }
 
+
+// TODO: is concurrency supported?
+// it seems that spool and spawn concurrent access is ensured by state machine.
 void
 external_t::metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const {
 

--- a/node/src/isolate/external.cpp
+++ b/node/src/isolate/external.cpp
@@ -492,17 +492,15 @@ void
 external_t::metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const {
 
     auto load = std::make_shared<metrics_load_t>(inner, query, handle);
-    // implicitly copy this->inner to a variable to capture it to avoid expiration of inner
-    auto _inner = inner;
 
-    _inner->io_context.post([=](){
-        if(_inner->session && _inner->prepared) {
-            COCAINE_LOG_DEBUG(_inner->log, "processing metrics request");
+    inner->io_context.post([=](){
+        if(inner->session && inner->prepared) {
+            COCAINE_LOG_DEBUG(inner->log, "processing metrics request");
             load->apply();
         } else {
-            COCAINE_LOG_DEBUG(_inner->log, "can't send metrics request, session not ready");
-            if(_inner->prepared) {
-                _inner->connect();
+            COCAINE_LOG_DEBUG(inner->log, "can't send metrics request, session not ready");
+            if(inner->prepared) {
+                inner->connect();
             }
         }
     });

--- a/node/src/isolate/external.cpp
+++ b/node/src/isolate/external.cpp
@@ -97,16 +97,13 @@ struct metrics_dispatch_t :
     typedef io::protocol<io::event_traits<io::isolate::metrics>::upstream_type>::scope protocol;
 
     metrics_dispatch_t(const std::string &name, std::shared_ptr<api::metrics_handle_base_t> handle)
-        : dispatch(name),
-          metrics_handle(std::move(handle))
+        : dispatch(name)
     {
         namespace ph = std::placeholders;
 
-        on<protocol::value>(std::bind(&api::metrics_handle_base_t::on_data, metrics_handle, ph::_1));
-        on<protocol::error>(std::bind(&api::metrics_handle_base_t::on_error, metrics_handle, ph::_1, ph::_2));
+        on<protocol::value>(std::bind(&api::metrics_handle_base_t::on_data, handle, ph::_1));
+        on<protocol::error>(std::bind(&api::metrics_handle_base_t::on_error, handle, ph::_1, ph::_2));
     }
-
-    std::shared_ptr<api::metrics_handle_base_t> metrics_handle;
 };
 
 struct spool_load_t :

--- a/node/src/isolate/process.cpp
+++ b/node/src/isolate/process.cpp
@@ -437,6 +437,5 @@ process_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t>
     COCAINE_LOG_WARNING(m_log, "legacy_process::metrics not implemented");
 }
 
-
 } // namespace isolate
 } // namespace cocaine

--- a/node/src/isolate/process.cpp
+++ b/node/src/isolate/process.cpp
@@ -431,5 +431,12 @@ process_t::spawn(const std::string& path,
     std::_Exit(EXIT_FAILURE);
 }
 
+void
+process_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t>) const
+{
+    COCAINE_LOG_WARNING(m_log, "legacy_process::metrics not implemented");
+}
+
+
 } // namespace isolate
 } // namespace cocaine

--- a/node/src/isolate/process.cpp
+++ b/node/src/isolate/process.cpp
@@ -32,6 +32,7 @@
 #include <array>
 #include <iostream>
 
+#include <cassert>
 #include <csignal>
 
 #include <asio/deadline_timer.hpp>
@@ -432,9 +433,10 @@ process_t::spawn(const std::string& path,
 }
 
 void
-process_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t>) const
+process_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t> handle) const
 {
-    COCAINE_LOG_WARNING(m_log, "legacy_process::metrics not implemented");
+    assert(handle);
+    return handle->on_data({});
 }
 
 } // namespace isolate

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -471,17 +471,16 @@ private:
     }
 
     struct observer_adapter_t : public pool_observer {
-        using pool_observer::despawned;
 
         observer_adapter_t(running_t& rstate) :
             parent(rstate)
         {}
 
-        virtual auto despawned() -> void override {
+        auto despawned(const std::string&) -> void override {
             parent.despawned();
         }
 
-        virtual auto spawned() -> void override {
+        auto spawned(const std::string&) -> void override {
             parent.spawned();
         }
 

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -471,6 +471,8 @@ private:
     }
 
     struct observer_adapter_t : public pool_observer {
+        using pool_observer::despawned;
+
         observer_adapter_t(running_t &rstate) :
             parent(rstate)
         {}

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -337,8 +337,7 @@ public:
 
 /// The application has been published and currently running.
 class running_t:
-    public base_t,
-    public pool_observer
+    public base_t
 {
     logging::logger_t* const log;
 
@@ -361,7 +360,7 @@ public:
     {
         // Create an Overseer - slave spawner/despawner plus the event queue dispatcher.
         overseer_ = std::make_shared<overseer_proxy_t>(
-            std::make_shared<overseer_t>(context, manifest, profile, *this, loop)
+            std::make_shared<overseer_t>(context, manifest, profile, std::make_shared<observer_adapter_t>(*this), loop)
         );
 
         // Create an unix actor and bind to {manifest->name}.{pid} unix-socket.
@@ -470,6 +469,23 @@ private:
             COCAINE_LOG_WARNING(log, "failed to remove application service from the context: {}", err.what());
         }
     }
+
+    struct observer_adapter_t : public pool_observer {
+        observer_adapter_t(running_t &rstate) :
+            parent(rstate)
+        {}
+
+        virtual auto despawned() -> void override {
+            parent.despawned();
+        }
+
+        virtual auto spawned() -> void override {
+            parent.spawned();
+        }
+
+    private:
+        running_t &parent;
+    };
 };
 
 } // namespace state
@@ -477,7 +493,6 @@ private:
 class cocaine::service::node::app_state_t
     : public std::enable_shared_from_this<cocaine::service::node::app_state_t>
 {
-
     const std::unique_ptr<logging::logger_t> log;
 
     context_t& context;

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -473,7 +473,7 @@ private:
     struct observer_adapter_t : public pool_observer {
         using pool_observer::despawned;
 
-        observer_adapter_t(running_t &rstate) :
+        observer_adapter_t(running_t& rstate) :
             parent(rstate)
         {}
 
@@ -486,7 +486,7 @@ private:
         }
 
     private:
-        running_t &parent;
+        running_t& parent;
     };
 };
 

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -156,7 +156,7 @@ public:
     /// Cancels all asynchronous pending operations, preparing for destruction.
     auto cancel() -> void;
 
-    auto attach_pool_observer(const std::shared_ptr<pool_observer>& observer) -> void;
+    auto attach_pool_observer(std::shared_ptr<pool_observer> observer) -> void;
 private:
     /// Spawns a slave using current manifest and profile.
     auto spawn(pool_type& pool) -> void;

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -73,9 +73,10 @@ public:
     /// Statistics.
     stats_t stats;
 
-    class metrics_retriever_t;
+    /// Active isolation workers metrics sampler
+    /// poll sequence should be initialized explicitly with
+    /// metrics_retriever_t::ignite_poll method
     std::shared_ptr<metrics_retriever_t> metrics_retriever_impl;
-
 public:
     engine_t(context_t& context,
              manifest_t manifest,

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -65,7 +65,7 @@ public:
     std::chrono::system_clock::time_point last_failed;
     std::chrono::seconds last_timeout;
 
-    pool_observer& observer;
+    std::vector<std::shared_ptr<pool_observer>> observers;
 
     /// Pending queue.
     synchronized<queue_type> queue;
@@ -81,7 +81,7 @@ public:
     engine_t(context_t& context,
              manifest_t manifest,
              profile_t profile,
-             pool_observer& observer,
+             std::shared_ptr<pool_observer> observer,
              std::shared_ptr<asio::io_service> loop);
 
     ~engine_t();
@@ -154,6 +154,7 @@ public:
     /// Cancels all asynchronous pending operations, preparing for destruction.
     auto cancel() -> void;
 
+    auto attach_pool_observer(const std::shared_ptr<pool_observer>& observer) -> void;
 private:
     /// Spawns a slave using current manifest and profile.
     auto spawn(pool_type& pool) -> void;

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -65,7 +65,8 @@ public:
     std::chrono::system_clock::time_point last_failed;
     std::chrono::seconds last_timeout;
 
-    std::vector<std::shared_ptr<pool_observer>> observers;
+    using observers_type = std::vector<std::shared_ptr<pool_observer>>;
+    synchronized<observers_type> observers;
 
     /// Pending queue.
     synchronized<queue_type> queue;
@@ -73,9 +74,10 @@ public:
     /// Statistics.
     stats_t stats;
 
-    /// Active isolation workers metrics sampler
-    /// poll sequence should be initialized explicitly with
-    /// metrics_retriever_t::ignite_poll method
+    /// Isolation daemon's workers metrics sampler.
+    /// Poll sequence should be initialized explicitly with
+    /// metrics_retriever_t::ignite_poll method or implicitly
+    /// within metrics_retriever_t::make_and_ignite.
     std::shared_ptr<metrics_retriever_t> metrics_retriever_impl;
 public:
     engine_t(context_t& context,

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -73,6 +73,9 @@ public:
     /// Statistics.
     stats_t stats;
 
+    class metrics_retriever_t;
+    std::shared_ptr<metrics_retriever_t> metrics_retriever_impl;
+
 public:
     engine_t(context_t& context,
              manifest_t manifest,

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -78,7 +78,7 @@ public:
     /// Poll sequence should be initialized explicitly with
     /// metrics_retriever_t::ignite_poll method or implicitly
     /// within metrics_retriever_t::make_and_ignite.
-    std::shared_ptr<metrics_retriever_t> metrics_retriever_impl;
+    std::shared_ptr<metrics_retriever_t> metrics_retriever;
 public:
     engine_t(context_t& context,
              manifest_t manifest,

--- a/node/src/node/isometrics.cpp
+++ b/node/src/node/isometrics.cpp
@@ -1,15 +1,16 @@
 #include <tuple>
 #include <cassert>
 
-#include "cocaine/detail/service/node/isometrics.hpp"
+#include "isometrics.hpp"
 
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/numeric.hpp>
 
-#include <boost/utility/string_ref.hpp>
+// #define ISOMETRICS_DEBUG
+#undef ISOMETRICS_DEBUG
 
-#if 0
+#ifdef ISOMETRICS_DEBUG
 #define dbg(msg) std::cerr << msg << '\n'
 #define DBG_DUMP_UUIDS(os, logo, container) aux::dump_uuids(os, logo, container)
 #else
@@ -25,31 +26,30 @@ namespace node {
 namespace ph = std::placeholders;
 
 namespace conf {
-    const auto METRICS_POLL_INTERVAL = boost::posix_time::seconds(2);
-
     constexpr auto PURGATORY_QUEUE_BOUND = 8 * 1024;
+    constexpr auto SHOW_ERRORS_LIMIT = 3;
 
-    // <name, should be metric zeroed on empty workers list>
-    const std::vector<std::pair<std::string, bool>> metrics_names =
+    // <name, is metric monotonically increasing per application (aggregate) level>
+    const std::vector<std::pair<std::string, bool>> counter_metrics_names =
     {
         // yet abstract cpu load measurement
-        { "cpu", true},
+        { "cpu", false},
+
+        // memory usage (in bytes)
+        { "vms", false },
+        { "rss", false },
 
         // running times
         { "uptime",    true },
         { "user_time", true },
         { "sys_time",  true },
 
-        // memory usage (in bytes)
-        { "vms", true },
-        { "rss", true },
-
         // disk io (in bytes)
-        { "ioread",  false },
-        { "iowrite", false },
+        { "ioread",  true },
+        { "iowrite", true },
 
-        // threads stats
-        // "threads_count"
+        // TODO: network stats
+
     };
 }
 
@@ -61,13 +61,13 @@ namespace aux {
 
     template<>
     auto
-    uuid_value<std::string>(const std::string& v) -> std::string {
+    uuid_value(const std::string& v) -> std::string {
         return v;
     }
 
     template<>
     auto
-    uuid_value<dynamic_t>(const dynamic_t& arr) -> std::string {
+    uuid_value(const dynamic_t& arr) -> std::string {
         return arr.as_string();
     }
 
@@ -76,7 +76,7 @@ namespace aux {
     dump_uuids(std::ostream& os, const std::string& logo, const Container& arr) -> void {
         os << logo << " size " << arr.size() << '\n';
         for(const auto& uuid : arr) {
-            std::cerr << "\tuuid: " << uuid_value(uuid) << '\n';
+            os << "\tuuid: " << uuid_value(uuid) << '\n';
         }
     }
 }
@@ -85,16 +85,18 @@ auto
 metrics_aggregate_proxy_t::operator+(const worker_metrics_t& worker_metrics) -> metrics_aggregate_proxy_t&
 {
     using boost::adaptors::map_keys;
+    using counters_record_type = worker_metrics_t::counters_record_type;
 
     dbg("worker_metrics_t::operator+() summing to proxy");
 
-    boost::for_each(worker_metrics.common_counters | map_keys, [&] (const std::string &name) {
-        const auto& counters = worker_metrics.common_counters;
+    boost::for_each(worker_metrics.common_counters, [&](const counters_record_type &worker_record) {
+        const auto& name = worker_record.first;
+        const auto& metric = worker_record.second;
 
-        const auto it = counters.find(name);
-        if (it != std::end(counters)) {
-            this->common_counters[name] += it->second->load();
-        }
+        auto& self_record = this->common_counters[name];
+
+        self_record.values += metric.value->load();
+        self_record.deltas += metric.delta;
     });
 
     return *this;
@@ -112,40 +114,50 @@ worker_metrics_t::operator=(metrics_aggregate_proxy_t&& proxy) -> worker_metrics
     dbg("worker_metrics_t::operator=() moving from proxy");
 
     if (proxy.common_counters.empty()) {
+
         // no active workers, zero out some metrics values
-        for(const auto& metrics : conf::metrics_names) {
-            const auto& name = metrics.first;
-            const auto& must_be_zeroed = metrics.second;
+        for(const auto& init_metrics : conf::counter_metrics_names) {
+            const auto& name = init_metrics.first;
+            const auto& must_be_preserved = init_metrics.second;
 
-            dbg("should be zeroed " << name << ", must_be_zeroed " << must_be_zeroed);
+            dbg("preserved " << name << " : " << must_be_preserved);
 
-            auto it = this->common_counters.find(name);
-            if (it != std::end(this->common_counters) && must_be_zeroed) {
-                    it->second->store(0);
+            auto self_it = this->common_counters.find(name);
+            if (self_it != std::end(this->common_counters) && must_be_preserved == false) {
+                    self_it->second.value->store(0);
             }
         }
+
     } else {
-        for(const auto& metrics : proxy.common_counters) {
-            const auto& name = metrics.first;
-            const auto& value = metrics.second;
+
+        for(const auto& proxy_metrics : proxy.common_counters) {
+            const auto& name = proxy_metrics.first;
+            const auto& proxy_record = proxy_metrics.second;
 
             auto self_it = this->common_counters.find(name);
             if (self_it != std::end(this->common_counters)) {
-                self_it->second->store(value);
-            }
-        }
-    }
+                auto& self_record = self_it->second;
 
+                if (self_record.is_accumulated) { // monotonically increasing
+                    self_record.value->fetch_add(proxy_record.deltas);
+                } else {
+                    self_record.value->store(proxy_record.values);
+                }
+            }
+
+        } // for metrics in proxy
+    }
 
     return *this;
 }
 
+// TODO: error messages processing
 struct response_processor_t {
     using stats_table_type = metrics_retriever_t::stats_table_type;
 
     struct error_t {
-        int code;
-        std::string msg;
+        long code;
+        std::string message;
     };
 
     response_processor_t(const std::string app_name) :
@@ -154,19 +166,19 @@ struct response_processor_t {
     {}
 
     auto
-    operator()(context_t &ctx, const dynamic_t& response, stats_table_type& stats_table) -> size_t {
+    operator()(context_t& ctx, const dynamic_t& response, stats_table_type& stats_table) -> size_t {
         return process(ctx, response, stats_table);
     }
 
     auto
-    process(context_t &ctx, const dynamic_t& response, stats_table_type& stats_table) -> size_t {
+    process(context_t& ctx, const dynamic_t& response, stats_table_type& stats_table) -> size_t {
         const auto apps = response.as_object();
 
         auto uuids_processed = size_t{};
 
         for(const auto& app : apps) {
 
-            // TODO: restore app_name check
+            // TODO: restore app_name assertion check
             //
             // strictly, we should have one app at all within current protocol
             // if (app_name != app.first) {
@@ -181,30 +193,32 @@ struct response_processor_t {
                 const auto& metrics = item.second.as_object();
 
                 if (uuid.empty()) {
-                    dbg("[response] uuid value is empty");
+                    dbg("[response] 'uuid' value is empty, ignoring");
+                    continue;
+                }
+
+                if (uuid.compare("error") == 0) {
+                    parse_error_record(metrics);
                     continue;
                 }
 
                 auto stat_it = stats_table.find(uuid);
                 if (stat_it == std::end(stats_table)) {
+                    // If isolate daemon sends us uuid we don't know about,
+                    // add it to the stats (monitoring) table. If it was send by error, it
+                    // would be removed from request list and from stats table
+                    // on next poll iteration preparation.
                     dbg("[response] inserting new metrics record with uuid" << uuid);
                     tie(stat_it, std::ignore) = stats_table.emplace(uuid, worker_metrics_t{ctx, app_name, uuid});
                 }
 
                 auto common_it = metrics.find("common");
                 if (common_it == std::end(metrics)) {
-                    dbg("[response] no `common` secion");
+                    dbg("[response] no `common` section");
                     continue;
                 }
 
-#if 0
-                for(const auto& el : common_it->second.as_object()) {
-                    dbg("[response] metric name " << el.first);
-                }
-#endif
-
                 fill_metrics(common_it->second.as_object(), stat_it->second.common_counters);
-
                 ++uuids_processed;
             }
         }
@@ -237,12 +251,28 @@ struct response_processor_t {
 private:
 
     auto
+    parse_error_record(const dynamic_t::object_t& metrics) -> void {
+        const auto& error_message = metrics.at("error.message", "none").as_string();
+        const auto& error_code    = metrics.at("error.code", 0).as_int();
+
+        errors.emplace_back(error_t{error_code, error_message});
+
+        dbg("[response] got an error: " << error_message << " code: " << error_code);
+    }
+
+    auto
     fill_metrics(const dynamic_t::object_t& metrics, worker_metrics_t::counters_table_type& result) -> void {
+
+        if (metrics.count("error.message")) {
+            parse_error_record(metrics);
+        }
+
         for(const auto& metric : metrics) {
             const auto& name = metric.first;
 
             dbg("[response] metrics name: " << name);
 
+            // cut off type from name
             const auto pos = name.find('.');
             const auto nm = name.substr(0, pos);
 
@@ -253,15 +283,25 @@ private:
             }
 
             try {
-
                 auto r = result.find(nm);
                 if (r != std::end(result)) {
-                    dbg("[response] found metrics record for " << nm << ", updating");
-                    r->second->store(metric.second.as_uint());
-                }
+                    // we are interested in this metrics, its name was registered
+                    dbg("[response] found metrics record for " << nm << ", updating...");
 
-            // note: boost::bad_get in current implementaion
-            } catch (const std::exception &e) {
+                    auto& record = r->second;
+                    const auto& incoming_value = metric.second.as_uint();
+
+                    if (record.is_accumulated) {
+                        const auto& current = record.value->load();
+                        if (incoming_value >= current) {
+                            record.delta = incoming_value - current;
+                        } // else: client misbehavior, shouldn't try to store negative deltas
+                    }
+
+                    record.value->store(incoming_value);
+                }
+            // note: e is boost::bad_get in current implementaion
+            } catch (const std::exception& e) {
                 dbg("[response] parsing exception: " << e.what());
                 continue;
             }
@@ -275,15 +315,20 @@ private:
     std::string app_name;
 
     bool processed;
-
     std::vector<error_t> errors;
 };
 
 worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string& name_prefix)
 {
-    for(const auto& metric_name : conf::metrics_names) {
-        const auto& name = metric_name.first;
-        common_counters.emplace(name, ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}", name_prefix, name)));
+    for(const auto& metrics_init : conf::counter_metrics_names) {
+        const auto& name = metrics_init.first;
+        const auto& is_aggregate = metrics_init.second;
+
+        common_counters.emplace(name,
+            counter_metric_t{
+                is_aggregate,
+                ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}", name_prefix, name)),
+                0 });
     }
 }
 
@@ -295,6 +340,7 @@ metrics_retriever_t::self_metrics_t::self_metrics_t(context_t& ctx, const std::s
    uuid_requested{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.uuid_requested", name))},
    uuid_recieved{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.uuid_recieved", name))},
    requests_send{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.requests", name))},
+   responses_received{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.responses", name))},
    receive_errors{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.recieve.errors", name))},
    posmortem_queue_size{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.postmortem.queue.size", name))}
 {}
@@ -304,7 +350,8 @@ metrics_retriever_t::metrics_retriever_t(
     const std::string& name, // app name
     std::shared_ptr<api::isolate_t> isolate,
     synchronized<engine_t::pool_type>& pool,
-    asio::io_service& loop) :
+    asio::io_service& loop,
+    const std::uint64_t poll_interval) :
         context(ctx),
         metrics_poll_timer(loop),
         isolate(std::move(isolate)),
@@ -312,6 +359,7 @@ metrics_retriever_t::metrics_retriever_t(
         log(ctx.log(format("{}/workers_metrics", name))),
         self_metrics(ctx, "node.isolate.poll.metrics"),
         app_name(name),
+        poll_interval(poll_interval),
         app_aggregate_metrics(ctx, cocaine::format("{}.isolate", name))
 {
     COCAINE_LOG_INFO(log, "worker metrics retriever has been initialized");
@@ -319,7 +367,7 @@ metrics_retriever_t::metrics_retriever_t(
 
 auto
 metrics_retriever_t::ignite_poll() -> void {
-    metrics_poll_timer.expires_from_now(conf::METRICS_POLL_INTERVAL);
+    metrics_poll_timer.expires_from_now(poll_interval);
     metrics_poll_timer.async_wait(std::bind(&metrics_retriever_t::poll_metrics, shared_from_this(), ph::_1));
 }
 
@@ -327,13 +375,13 @@ auto
 metrics_retriever_t::add_post_mortem(const std::string& id) -> void {
     if (purgatory->size() >= conf::PURGATORY_QUEUE_BOUND) {
         // on high despawn rates stat of some unlucky workers will be lost
+        COCAINE_LOG_INFO(log, "worker metrics retriever: dead worker stat will be discarded for {}", id);
         return;
     }
 
-    self_metrics.posmortem_queue_size->store(purgatory->size());
-
-    purgatory.apply([&] (purgatory_pot_type &pot) {
+    purgatory.apply([&](purgatory_pot_type& pot) {
         pot.emplace(id);
+        self_metrics.posmortem_queue_size->store(pot.size());
     });
 }
 
@@ -362,9 +410,11 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
 
     DBG_DUMP_UUIDS(std::cerr, "metrics.pool", alive_uuids);
 
-    purgatory.apply([&](const purgatory_pot_type &pot) {
+#ifdef ISOMETRICS_DEBUG
+    purgatory.apply([&](const purgatory_pot_type& pot) {
         DBG_DUMP_UUIDS(std::cerr, "purgatory", pot);
     });
+#endif
 
     dynamic_t::array_t query_array;
     query_array.reserve(alive_uuids.size() + purgatory->size());
@@ -375,9 +425,10 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     // will increase significantly
     boost::sort(alive_uuids);
 
-    purgatory.apply([&] (purgatory_pot_type& pot) {
+    purgatory.apply([&](purgatory_pot_type& pot) {
         boost::set_union(alive_uuids, pot, std::back_inserter(query_array));
         pot.clear();
+        self_metrics.posmortem_queue_size->store(0);
     });
 
     DBG_DUMP_UUIDS(std::cerr, "query array", query_array);
@@ -428,12 +479,15 @@ metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
     dbg("metrics_handle_t:::on_data");
     dbg("[response] get json: " << boost::lexical_cast<std::string>(data) << '\n');
 
+    COCAINE_LOG_DEBUG(parent->log, "processing isolation metrics response");
+
+    response_processor_t processor(parent->app_name);
+
     // should not harm performance, as this handler would be called from same
     // poll loop, within same thread on each poll iteration
     const auto processed_count = parent->metrics.apply([&](metrics_retriever_t::stats_table_type& table) {
-        response_processor_t processor(parent->app_name);
 
-        // fill worker current `slice` metrics table
+        // fill workers current `slice` state of metrics table
         const auto processed_count = processor(parent->context, data, table);
 
         // update application-wide aggregate of metrics
@@ -443,13 +497,28 @@ metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
     });
 
     parent->self_metrics.uuid_recieved->fetch_add(processed_count);
+    parent->self_metrics.responses_received->fetch_add(1);
+
+    if (processor.has_errors()) {
+            const auto& errors = processor.errors_ref();
+            auto break_counter = int{};
+
+            for(const auto& e : errors) {
+                if (++break_counter > conf::SHOW_ERRORS_LIMIT) {
+                    break;
+                }
+                COCAINE_LOG_DEBUG(parent->log, "isolation metrics got an error {} {}", e.code, e.message);
+            }
+    }
 }
 
 auto
-metrics_retriever_t::metrics_handle_t::on_error(const std::error_code&, const std::string& what) -> void {
+metrics_retriever_t::metrics_handle_t::on_error(const std::error_code& error, const std::string& what) -> void {
     assert(parent);
     dbg("metrics_handle_t::on_error: " << what);
+
     // TODO: start crying?
+    COCAINE_LOG_WARNING(parent->log, "worker metrics recieve error {}:{}", error, what);
     parent->self_metrics.receive_errors->fetch_add(1);
 }
 

--- a/node/src/node/isometrics.cpp
+++ b/node/src/node/isometrics.cpp
@@ -16,21 +16,106 @@ namespace conf {
     constexpr auto PURGATORY_QUEUE_BOUND = 8 * 1024;
 }
 
-worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string &app_name, const std::string &id) :
-    // running times
-    uptime{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}.{}.uptime", app_name, "worker", id))},
-    user_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}.{}.user_time", app_name, "worker", id))},
-    sys_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}.{}.sys_time", app_name, "worker", id))},
+// TODO: hardly WIP
+struct response_processor_t {
+    using stats_table_type = metrics_retriever_t::stats_table_type;
 
-    // memory gages
-    vms{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.{}.{}.vms", app_name, "worker", id))},
-    rss{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.{}.{}.rss", app_name, "worker", id))},
+    struct error_t {
+        int code;
+        std::string msg;
+    };
+
+    response_processor_t(
+        const std::string app_name,
+        dynamic_t& response,
+        stats_table_type &stats_table) :
+            app_name(app_name),
+            response(response),
+            stats_table(stats_table),
+            processed{false}
+    {
+        this->process();
+    }
+
+    auto
+    process() -> void {
+        const auto apps = response.as_object();
+
+        // strictly, we should have one app at all by current protocol
+        for(const auto &app : apps) {
+
+            if (app_name != app.first) {
+                continue;
+            }
+
+            const auto uuids = app.second.as_array();
+
+            for(const auto &it : uuids) {
+                const auto records = it.as_object();
+
+                // TODO: do funny things
+
+            }
+        }
+
+        processed = true;
+    }
+
+    auto
+    is_processed() const -> bool {
+        return processed;
+    }
+
+    auto
+    errors_count() const -> std::size_t {
+        return errors.size();
+    }
+
+    auto
+    metrics_ref() -> const stats_table_type& {
+        return stats_table;
+    }
+
+    auto
+    errors_ref() -> const std::vector<error_t>& {
+        return errors;
+    }
+
+private:
+    std::string app_name;
+
+    dynamic_t& response;
+    stats_table_type& stats_table;
+
+    bool processed;
+
+    std::vector<error_t> errors;
+};
+
+
+worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string& name_prefix) :
+    // running times
+    uptime{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.uptime", name_prefix))},
+    user_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.user_time", name_prefix))},
+    sys_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.sys_time", name_prefix))},
+
+    // memory usage
+    vms{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.vms", name_prefix))},
+    rss{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.rss", name_prefix))},
+
+    // io disk
+    ioread{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.ioread", name_prefix))},
+    iowrite{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.iowrite", name_prefix))},
 
     // threads
-    threads_count{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.{}.{}.threads_count", app_name, "worker", id))}
+    threads_count{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.threads_count", name_prefix))}
 {}
 
-metrics_retriever_t::self_metrics_t(context_t &ctx, const std::string &name) :
+worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string& app_name, const std::string& id) :
+    worker_metrics_t(ctx, cocaine::format("{}.{}", app_name, id))
+{}
+
+metrics_retriever_t::self_metrics_t::self_metrics_t(context_t& ctx, const std::string& name) :
    uuid_requested{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.requested", name))},
    uuid_recieved{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.recieved", name))},
    receive_errors{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.errors.count", name))},
@@ -38,18 +123,19 @@ metrics_retriever_t::self_metrics_t(context_t &ctx, const std::string &name) :
 {}
 
 metrics_retriever_t::metrics_retriever_t(
-    context_t &ctx,
-    const std::string &name, // app name
+    context_t& ctx,
+    const std::string& name, // app name
     std::shared_ptr<api::isolate_t> isolate,
-    synchronized<engine_t::pool_type> &pool,
-    asio::io_service &loop) :
+    synchronized<engine_t::pool_type>& pool,
+    asio::io_service& loop) :
         context(ctx),
         metrics_poll_timer(loop),
         isolate(std::move(isolate)),
         pool(pool),
         log(ctx.log(format("{}/workers_metrics", name))),
         self_metrics(ctx, cocaine::format("node.metrics.sampler.{}.", name)),
-        app_name(name)
+        app_name(name),
+        app_aggregate_metrics(ctx, name)
 {
     COCAINE_LOG_INFO(log, "worker metrics retriever has been initialized");
 }
@@ -61,13 +147,13 @@ metrics_retriever_t::ignite_poll() -> void {
 }
 
 auto
-metrics_retriever_t::add_post_mortem(const std::string &id) -> void {
-    if (purgatory.size() >= conf::PURGATORY_QUEUE_BOUND) {
+metrics_retriever_t::add_post_mortem(const std::string& id) -> void {
+    if (purgatory->size() >= conf::PURGATORY_QUEUE_BOUND) {
         // on high despawn rates stat of some unlucky workers will be lost
         return;
     }
 
-    self_metrics.posmortem_queue_size->store(purgatory.size());
+    self_metrics.posmortem_queue_size->store(purgatory->size());
 
     purgatory.apply([&] (purgatory_pot_type &pot) {
         pot.emplace(id);
@@ -76,6 +162,8 @@ metrics_retriever_t::add_post_mortem(const std::string &id) -> void {
 
 auto
 metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
+    using boost::adaptors::map_keys;
+
     if (ec) {
         // cancelled
         COCAINE_LOG_WARNING(log, "workers metrics polling was cancelled");
@@ -87,13 +175,13 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
         return;
     }
 
-    auto alive_uuids = pool.apply([] (const pool_type& pool) {
+    auto alive_uuids = pool.apply([] (const engine_t::pool_type& pool) {
         std::vector<std::string> alive;
         alive.reserve(pool.size());
 
         // TODO: should we take active workers only?
 
-        boost::copy(pool | boost::adaptors::map_keys, std::back_inserter(alive));
+        boost::copy(pool | map_keys, std::back_inserter(alive));
         return alive;
     });
 
@@ -113,14 +201,14 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     // will increase significantly
     boost::sort(alive_uuids);
 
-    purgatory.apply([&] (purgatory_pot_type &pot) {
+    purgatory.apply([&] (purgatory_pot_type& pot) {
         boost::set_union(alive_uuids, pot, std::back_inserter(query_array));
         pot.clear();
     });
 
 #if 1
     std::cerr << "query array size: " << query_array.size() << '\n';
-    for(const auto &el : query_array) {
+    for(const auto& el : query_array) {
         std::cerr << "\tuuid: " << el.as_string() << '\n';
     }
 #endif
@@ -134,8 +222,10 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     ignite_poll();
 }
 
+//// metrics_handle_t //////////////////////////////////////////////////////////
+
 auto
-metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> voido {
+metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
     std::cerr << "metrics_handle_t:::on_data TBD\n";
     std::cerr << "get json: " << boost::lexical_cast<std::string>(data) << '\n';
 
@@ -143,6 +233,27 @@ metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> voido {
     parent->self_metrics.uuid_recieved->fetch_add(1);
 }
 
+template<typename Observers>
+auto
+metrics_retriever_t::make_and_ignite(
+    context_t& ctx,
+    const std::string& name,
+    std::shared_ptr<api::isolate_t> isolate,
+    synchronized<engine_t::pool_type>& pool,
+    asio::io_service& loop, Observers& observers) -> std::shared_ptr<metrics_retriever_t>
+{
+    auto retriever = std::make_shared<metrics_retriever_t>(ctx, name, std::move(isolate), pool, loop);
+
+    observers->emplace_back(retriever->make_observer());
+    retriever->ignite_poll();
+
+    return retriever;
+}
+
+auto
+metrics_retriever_t::make_observer() -> std::shared_ptr<pool_observer> {
+    return std::make_shared<metrics_pool_observer_t>(*this);
+}
 
 auto
 metrics_retriever_t::metrics_handle_t::on_error(const std::error_code&, const std::string& what) -> void {
@@ -150,7 +261,6 @@ metrics_retriever_t::metrics_handle_t::on_error(const std::error_code&, const st
     // TODO
     parent->self_metrics.receive_errors->fetch_add(1);
 }
-
 
 } // namespace node
 } // namespace service

--- a/node/src/node/isometrics.cpp
+++ b/node/src/node/isometrics.cpp
@@ -1,7 +1,18 @@
+#include <tuple>
+#include <cassert>
+
 #include "cocaine/detail/service/node/isometrics.hpp"
 
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
+
+#include <boost/utility/string_ref.hpp>
+
+#if 1
+#define dbg(msg) std::cerr << (msg) << '\n'
+#else
+#define dbg(msg)
+#endif
 
 namespace cocaine {
 namespace detail {
@@ -14,7 +25,66 @@ namespace conf {
     const auto METRICS_POLL_INTERVAL = boost::posix_time::seconds(2);
 
     constexpr auto PURGATORY_QUEUE_BOUND = 8 * 1024;
+
+    const std::vector<std::string> metrics_names =
+    {
+        // yet abstract cpu load measurement
+        "cpu",
+
+        // running times
+        "uptime",
+        "user_time",
+        "sys_time",
+
+        // memory usage (in bytes)
+        "vms",
+        "rss",
+
+        // disk io (in bytes)
+        "ioread",
+        "iowrite",
+
+        // threads stats
+        "threads_count"
+    };
 }
+
+auto
+metrics_aggregate_proxy_t::operator+(const worker_metrics_t& worker_metrics) -> metrics_aggregate_proxy_t&
+{
+    for(const auto& name : conf::metrics_names) {
+
+        auto self_it = common_counters.find(name);
+        const auto worker_it = worker_metrics.common_counters.find(name);
+
+        if (self_it != std::end(common_counters) && worker_it != std::end(worker_metrics.common_counters) ) {
+            self_it->second += worker_it->second->load();
+        }
+    }
+
+    return *this;
+}
+
+auto
+operator+(worker_metrics_t& src, metrics_aggregate_proxy_t& proxy) -> metrics_aggregate_proxy_t&
+{
+    return proxy + src;
+}
+
+auto
+worker_metrics_t::operator=(metrics_aggregate_proxy_t&& proxy) -> worker_metrics_t& {
+    for(const auto& name : conf::metrics_names) {
+        auto self_it = this->common_counters.find(name);
+        const auto proxy_it = proxy.common_counters.find(name);
+
+        if (self_it != std::end(this->common_counters) && proxy_it != std::end(proxy.common_counters) ) {
+            self_it->second->store(proxy_it->second);
+        }
+    }
+
+    return *this;
+}
+
 
 // TODO: hardly WIP
 struct response_processor_t {
@@ -25,40 +95,57 @@ struct response_processor_t {
         std::string msg;
     };
 
-    response_processor_t(
-        const std::string app_name,
-        dynamic_t& response,
-        stats_table_type &stats_table) :
-            app_name(app_name),
-            response(response),
-            stats_table(stats_table),
-            processed{false}
-    {
-        this->process();
+    response_processor_t(const std::string app_name) :
+        app_name(app_name),
+        processed{false}
+    {}
+
+    auto
+    operator()(context_t &ctx, const dynamic_t& response, stats_table_type& stats_table) -> size_t {
+        return process(ctx, response, stats_table);
     }
 
     auto
-    process() -> void {
+    process(context_t &ctx, const dynamic_t& response, stats_table_type& stats_table) -> size_t {
         const auto apps = response.as_object();
 
-        // strictly, we should have one app at all by current protocol
-        for(const auto &app : apps) {
+        auto uuids_processed = size_t{};
+
+        // strictly, we should have one app at all within current protocol
+        for(const auto& app : apps) {
 
             if (app_name != app.first) {
                 continue;
             }
 
-            const auto uuids = app.second.as_array();
+            const auto uuids = app.second.as_object();
 
-            for(const auto &it : uuids) {
-                const auto records = it.as_object();
+            for(const auto& item : uuids) {
+                const auto& uuid = item.first;
+                const auto& metrics = item.second.as_object();
 
-                // TODO: do funny things
+                if (uuid.empty()) {
+                    continue;
+                }
 
+                auto common_it = metrics.find("common");
+                if (common_it == std::end(metrics)) {
+                    continue;
+                }
+
+                auto victim = stats_table.find(uuid);
+                if (victim == std::end(stats_table)) {
+                    tie(victim, std::ignore) = stats_table.emplace(uuid, worker_metrics_t{ctx, app_name, uuid});
+                }
+
+                fill_metrics(common_it->second.as_object(), victim->second.common_counters);
+                ++uuids_processed;
             }
         }
 
         processed = true;
+
+        return uuids_processed;
     }
 
     auto
@@ -72,8 +159,8 @@ struct response_processor_t {
     }
 
     auto
-    metrics_ref() -> const stats_table_type& {
-        return stats_table;
+    has_errors() -> bool {
+        return ! errors.empty();
     }
 
     auto
@@ -82,42 +169,54 @@ struct response_processor_t {
     }
 
 private:
-    std::string app_name;
 
-    dynamic_t& response;
-    stats_table_type& stats_table;
+    auto
+    fill_metrics(const dynamic_t::object_t& metrics, worker_metrics_t::counters_table_type& result) -> void {
+        for(const auto& metric : metrics) {
+            const auto& name = metric.first;
+
+            const auto pos = name.find('.');
+            if (pos == boost::string_ref::npos) {
+                continue;
+            }
+
+            const auto nm   = name.substr(0, pos);
+            const auto type = name.substr(pos+1);
+
+            if (nm.empty() || type.empty()) {
+                continue;
+            }
+
+            auto r = result.find(nm);
+            if (r != std::end(result)) {
+                r->second->store(metric.second.as_double());
+            }
+        }
+    }
+
+private:
+    std::string app_name;
 
     bool processed;
 
     std::vector<error_t> errors;
 };
 
-
-worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string& name_prefix) :
-    // running times
-    uptime{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.uptime", name_prefix))},
-    user_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.user_time", name_prefix))},
-    sys_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.sys_time", name_prefix))},
-
-    // memory usage
-    vms{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.vms", name_prefix))},
-    rss{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.rss", name_prefix))},
-
-    // io disk
-    ioread{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.ioread", name_prefix))},
-    iowrite{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.iowrite", name_prefix))},
-
-    // threads
-    threads_count{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.threads_count", name_prefix))}
-{}
+worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string& name_prefix)
+{
+    for(const auto &name : conf::metrics_names) {
+        common_counters.emplace(name, ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}", name_prefix, name)));
+    }
+}
 
 worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string& app_name, const std::string& id) :
     worker_metrics_t(ctx, cocaine::format("{}.{}", app_name, id))
 {}
 
 metrics_retriever_t::self_metrics_t::self_metrics_t(context_t& ctx, const std::string& name) :
-   uuid_requested{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.requested", name))},
-   uuid_recieved{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.recieved", name))},
+   uuid_requested{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.uuid_requested", name))},
+   uuid_recieved{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.uuid_recieved", name))},
+   requests_send{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.requests", name))},
    receive_errors{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.errors.count", name))},
    posmortem_queue_size{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.postmortem.queue.size", name))}
 {}
@@ -179,8 +278,6 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
         std::vector<std::string> alive;
         alive.reserve(pool.size());
 
-        // TODO: should we take active workers only?
-
         boost::copy(pool | map_keys, std::back_inserter(alive));
         return alive;
     });
@@ -190,6 +287,15 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     for(const auto &el : alive_uuids) {
         std::cerr << "\tuuid: " << el << '\n';
     }
+#endif
+
+#if 1
+    std::cerr << "purgatory.pot.size " << purgatory->size() << '\n';
+    purgatory.apply([&](const purgatory_pot_type &pot) {
+        for(const auto &sinner : pot) {
+            std::cerr << "\tuuid: " << sinner << '\n';
+        }
+    });
 #endif
 
     dynamic_t::array_t query_array;
@@ -218,36 +324,9 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     isolate->metrics(query, std::make_shared<metrics_handle_t>(shared_from_this()));
 
     self_metrics.uuid_requested->fetch_add(query_array.size());
+    self_metrics.requests_send->fetch_add(1);
 
     ignite_poll();
-}
-
-//// metrics_handle_t //////////////////////////////////////////////////////////
-
-auto
-metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
-    std::cerr << "metrics_handle_t:::on_data TBD\n";
-    std::cerr << "get json: " << boost::lexical_cast<std::string>(data) << '\n';
-
-    // TODO
-    parent->self_metrics.uuid_recieved->fetch_add(1);
-}
-
-template<typename Observers>
-auto
-metrics_retriever_t::make_and_ignite(
-    context_t& ctx,
-    const std::string& name,
-    std::shared_ptr<api::isolate_t> isolate,
-    synchronized<engine_t::pool_type>& pool,
-    asio::io_service& loop, Observers& observers) -> std::shared_ptr<metrics_retriever_t>
-{
-    auto retriever = std::make_shared<metrics_retriever_t>(ctx, name, std::move(isolate), pool, loop);
-
-    observers->emplace_back(retriever->make_observer());
-    retriever->ignite_poll();
-
-    return retriever;
 }
 
 auto
@@ -255,8 +334,30 @@ metrics_retriever_t::make_observer() -> std::shared_ptr<pool_observer> {
     return std::make_shared<metrics_pool_observer_t>(*this);
 }
 
+//// metrics_handle_t //////////////////////////////////////////////////////////
+
+auto
+metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
+    assert(parent);
+
+    std::cerr << "metrics_handle_t:::on_data TBD\n";
+    std::cerr << "get json: " << boost::lexical_cast<std::string>(data) << '\n';
+
+    // should not harm performance, as this handler would be called from same
+    // poll loop, within same thread on each poll iteration
+    parent->metrics.apply([&](metrics_retriever_t::stats_table_type& table) {
+        response_processor_t processor(parent->app_name);
+        processor(parent->context, data, table);
+    });
+
+    // TODO
+    parent->self_metrics.uuid_recieved->fetch_add(1);
+}
+
 auto
 metrics_retriever_t::metrics_handle_t::on_error(const std::error_code&, const std::string& what) -> void {
+    assert(parent);
+
     std::cerr << "metrics_handle_t::on_error: " << what << '\n';
     // TODO
     parent->self_metrics.receive_errors->fetch_add(1);

--- a/node/src/node/isometrics.cpp
+++ b/node/src/node/isometrics.cpp
@@ -1,0 +1,158 @@
+#include "cocaine/detail/service/node/isometrics.hpp"
+
+#include <boost/range/adaptors.hpp>
+#include <boost/range/algorithm.hpp>
+
+namespace cocaine {
+namespace detail {
+namespace service {
+namespace node {
+
+namespace ph = std::placeholders;
+
+namespace conf {
+    const auto METRICS_POLL_INTERVAL = boost::posix_time::seconds(2);
+
+    constexpr auto PURGATORY_QUEUE_BOUND = 8 * 1024;
+}
+
+worker_metrics_t::worker_metrics_t(context_t& ctx, const std::string &app_name, const std::string &id) :
+    // running times
+    uptime{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}.{}.uptime", app_name, "worker", id))},
+    user_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}.{}.user_time", app_name, "worker", id))},
+    sys_time{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.{}.{}.sys_time", app_name, "worker", id))},
+
+    // memory gages
+    vms{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.{}.{}.vms", app_name, "worker", id))},
+    rss{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.{}.{}.rss", app_name, "worker", id))},
+
+    // threads
+    threads_count{ctx.metrics_hub().counter<uint64_t>(cocaine::format("{}.{}.{}.threads_count", app_name, "worker", id))}
+{}
+
+metrics_retriever_t::self_metrics_t(context_t &ctx, const std::string &name) :
+   uuid_requested{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.requested", name))},
+   uuid_recieved{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.recieved", name))},
+   receive_errors{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.errors.count", name))},
+   posmortem_queue_size{ctx.metrics_hub().counter<std::uint64_t>(cocaine::format("{}.postmortem.queue.size", name))}
+{}
+
+metrics_retriever_t::metrics_retriever_t(
+    context_t &ctx,
+    const std::string &name, // app name
+    std::shared_ptr<api::isolate_t> isolate,
+    synchronized<engine_t::pool_type> &pool,
+    asio::io_service &loop) :
+        context(ctx),
+        metrics_poll_timer(loop),
+        isolate(std::move(isolate)),
+        pool(pool),
+        log(ctx.log(format("{}/workers_metrics", name))),
+        self_metrics(ctx, cocaine::format("node.metrics.sampler.{}.", name)),
+        app_name(name)
+{
+    COCAINE_LOG_INFO(log, "worker metrics retriever has been initialized");
+}
+
+auto
+metrics_retriever_t::ignite_poll() -> void {
+    metrics_poll_timer.expires_from_now(conf::METRICS_POLL_INTERVAL);
+    metrics_poll_timer.async_wait(std::bind(&metrics_retriever_t::poll_metrics, shared_from_this(), ph::_1));
+}
+
+auto
+metrics_retriever_t::add_post_mortem(const std::string &id) -> void {
+    if (purgatory.size() >= conf::PURGATORY_QUEUE_BOUND) {
+        // on high despawn rates stat of some unlucky workers will be lost
+        return;
+    }
+
+    self_metrics.posmortem_queue_size->store(purgatory.size());
+
+    purgatory.apply([&] (purgatory_pot_type &pot) {
+        pot.emplace(id);
+    });
+}
+
+auto
+metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
+    if (ec) {
+        // cancelled
+        COCAINE_LOG_WARNING(log, "workers metrics polling was cancelled");
+        return;
+    }
+
+    if (!isolate) {
+        ignite_poll();
+        return;
+    }
+
+    auto alive_uuids = pool.apply([] (const pool_type& pool) {
+        std::vector<std::string> alive;
+        alive.reserve(pool.size());
+
+        // TODO: should we take active workers only?
+
+        boost::copy(pool | boost::adaptors::map_keys, std::back_inserter(alive));
+        return alive;
+    });
+
+#if 1
+    std::cerr << "metrics.pool.size " << alive_uuids.size() << '\n';
+    for(const auto &el : alive_uuids) {
+        std::cerr << "\tuuid: " << el << '\n';
+    }
+#endif
+
+    dynamic_t::array_t query_array;
+    query_array.reserve(alive_uuids.size() + purgatory->size());
+
+    // Note: it is promised by devs that active list should be quite
+    // small ~ hundreds of workers, so it seems reasonable to pay a little for
+    // sorting here, but code should be redisigned if average alive count
+    // will increase significantly
+    boost::sort(alive_uuids);
+
+    purgatory.apply([&] (purgatory_pot_type &pot) {
+        boost::set_union(alive_uuids, pot, std::back_inserter(query_array));
+        pot.clear();
+    });
+
+#if 1
+    std::cerr << "query array size: " << query_array.size() << '\n';
+    for(const auto &el : query_array) {
+        std::cerr << "\tuuid: " << el.as_string() << '\n';
+    }
+#endif
+
+    dynamic_t::object_t query;
+    query["uuids"] = query_array;
+    isolate->metrics(query, std::make_shared<metrics_handle_t>(shared_from_this()));
+
+    self_metrics.uuid_requested->fetch_add(query_array.size());
+
+    ignite_poll();
+}
+
+auto
+metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> voido {
+    std::cerr << "metrics_handle_t:::on_data TBD\n";
+    std::cerr << "get json: " << boost::lexical_cast<std::string>(data) << '\n';
+
+    // TODO
+    parent->self_metrics.uuid_recieved->fetch_add(1);
+}
+
+
+auto
+metrics_retriever_t::metrics_handle_t::on_error(const std::error_code&, const std::string& what) -> void {
+    std::cerr << "metrics_handle_t::on_error: " << what << '\n';
+    // TODO
+    parent->self_metrics.receive_errors->fetch_add(1);
+}
+
+
+} // namespace node
+} // namespace service
+} // namespace detail
+} // namespace cocaine

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -19,7 +19,7 @@ namespace node {
 overseer_t::overseer_t(context_t& context,
                        manifest_t manifest,
                        profile_t profile,
-                       pool_observer& observer,
+                       std::shared_ptr<pool_observer> observer,
                        std::shared_ptr<asio::io_service> loop)
     : engine(std::make_shared<engine_t>(context, manifest, profile, observer, loop)) {}
 

--- a/node/src/node/pool_observer.hpp
+++ b/node/src/node/pool_observer.hpp
@@ -17,7 +17,7 @@ public:
 
     virtual
     auto
-    despawned(const std::string& id) -> void;
+    despawned(const std::string& id) -> void = 0;
 };
 
 } // namespace node

--- a/node/src/node/pool_observer.hpp
+++ b/node/src/node/pool_observer.hpp
@@ -13,19 +13,11 @@ public:
     /// Called when a slave was spawned.
     virtual
     auto
-    spawned() -> void = 0;
-
-    /// Called when a slave was despawned.
-    virtual
-    auto
-    despawned() -> void = 0;
+    spawned(const std::string& id) -> void = 0;
 
     virtual
     auto
-    despawned(const std::string& /* id */) -> void
-    {
-        despawned();
-    }
+    despawned(const std::string& id) -> void;
 };
 
 } // namespace node

--- a/node/src/node/pool_observer.hpp
+++ b/node/src/node/pool_observer.hpp
@@ -22,7 +22,7 @@ public:
 
     virtual
     auto
-    despawned_with_id(const std::string& /* id */) -> void
+    despawned(const std::string& /* id */) -> void
     {
         despawned();
     }

--- a/node/src/node/pool_observer.hpp
+++ b/node/src/node/pool_observer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace cocaine {
 namespace service {
 namespace node {
@@ -17,6 +19,13 @@ public:
     virtual
     auto
     despawned() -> void = 0;
+
+    virtual
+    auto
+    despawned_with_id(const std::string& /* id */) -> void
+    {
+        despawned();
+    }
 };
 
 } // namespace node

--- a/node/tests/isolate_mock.cpp
+++ b/node/tests/isolate_mock.cpp
@@ -160,7 +160,7 @@ public:
 
         rusage ru;
         // note: values used as dummies and don't match real metrics meanings
-        if (getrusage(RUSAGE_THREAD, &ru)) {
+        if (getrusage(RUSAGE_SELF, &ru)) {
             // TODO: send errors?
         }
 

--- a/node/tests/isolate_mock.cpp
+++ b/node/tests/isolate_mock.cpp
@@ -153,7 +153,7 @@ public:
     boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const std::vector<hpack::header_t>&, tuple_type&& args, upstream_type&& upstream)
     {
-        const auto &query = std::get<0>(args);
+        const auto& query = std::get<0>(args);
         COCAINE_LOG_INFO(log, "metrics. {}", boost::lexical_cast<std::string>(query));
 
         sleep(1);
@@ -172,7 +172,6 @@ public:
                 dynamic_t::object_t metrics;
 
                 const auto total_time = ru.ru_utime.tv_sec + ru.ru_stime.tv_sec;
-
                 const auto cpu = total_time ?
                     ru.ru_utime.tv_sec / total_time * 100 :
                     0;
@@ -215,7 +214,7 @@ public:
         on<io::isolate::spool>(std::make_shared<spool_slot_t>());
         on<io::isolate::spawn>(std::make_shared<spawn_slot_t>());
         on<io::isolate::metrics>(std::make_shared<metrics_slot_t>());
-     }
+    }
 
     virtual
     auto

--- a/node/tests/isolate_mock.cpp
+++ b/node/tests/isolate_mock.cpp
@@ -79,17 +79,16 @@ struct spool_slot_t:
 {
 public:
     typedef typename io::aux::protocol_impl<typename io::event_traits<io::isolate::spool>::upstream_type>::type protocol;
-    typedef typename io::basic_slot<io::isolate::spool>::dispatch_type dispatch_type;
 
     virtual
-    boost::optional<std::shared_ptr<dispatch_type>>
+    result_type
     operator()(const std::vector<hpack::header_t>&, tuple_type&& args, upstream_type&& upstream)
     {
         COCAINE_LOG_INFO(log, "spool. {}, {}", boost::lexical_cast<std::string>(std::get<0>(args)), std::get<1>(args));
         sleep(1);
         upstream.send<protocol::value>();
         COCAINE_LOG_INFO(log, "spool. sent value");
-        return boost::optional<std::shared_ptr<dispatch_type>>(std::make_shared<spooled_dispatch_t>());
+        return result_type(std::make_shared<spooled_dispatch_t>());
     }
 };
 
@@ -98,17 +97,16 @@ struct spawn_slot_t:
 {
 public:
     typedef typename io::aux::protocol_impl<typename io::event_traits<io::isolate::spawn>::upstream_type>::type protocol;
-    typedef typename io::basic_slot<io::isolate::spawn>::dispatch_type dispatch_type;
 
     virtual
-    boost::optional<std::shared_ptr<dispatch_type>>
+    result_type
     operator()(tuple_type&& args, upstream_type&& upstream)
     {
         return operator()({}, std::move(args), std::move(upstream));
     }
 
     virtual
-    boost::optional<std::shared_ptr<dispatch_type>>
+    result_type    
     operator()(const std::vector<hpack::header_t>&, tuple_type&& args, upstream_type&& upstream)
     {
         aux::formatter_t formatter;
@@ -131,7 +129,7 @@ public:
         sleep(1);
         upstream.send<protocol::choke>();
         COCAINE_LOG_INFO(log, "spawn. done");
-        return boost::optional<std::shared_ptr<dispatch_type>>(std::make_shared<spawned_dispatch_t>());
+        return result_type(std::make_shared<spawned_dispatch_t>());
     }
 };
 
@@ -140,17 +138,16 @@ struct metrics_slot_t:
 {
 public:
     typedef typename io::aux::protocol_impl<typename io::event_traits<io::isolate::metrics>::upstream_type>::type protocol;
-    typedef typename io::basic_slot<io::isolate::metrics>::dispatch_type dispatch_type;
 
     virtual
-    boost::optional<std::shared_ptr<dispatch_type>>
+    result_type
     operator()(tuple_type&& args, upstream_type&& upstream)
     {
         return operator()({}, std::move(args), std::move(upstream));
     }
 
     virtual
-    boost::optional<std::shared_ptr<dispatch_type>>
+    result_type
     operator()(const std::vector<hpack::header_t>&, tuple_type&& args, upstream_type&& upstream)
     {
         const auto& query = std::get<0>(args);

--- a/node/tests/isolate_mock.cpp
+++ b/node/tests/isolate_mock.cpp
@@ -29,7 +29,26 @@
 #include <cocaine/rpc/dispatch.hpp>
 #include <cocaine/traits/dynamic.hpp>
 
+#include <sys/time.h>
+#include <sys/resource.h>
+
 namespace cocaine { namespace service {
+
+namespace aux {
+    struct formatter_t {
+        auto
+        operator()(const std::map<std::string, std::string>& data) -> std::string {
+            std::string result;
+            for(auto& pair: data) {
+                if(!result.empty()) {
+                    result += ", ";
+                }
+                result += pair.first + ":" + pair.second;
+            }
+            return result;
+        }
+    };
+}
 
 std::unique_ptr<cocaine::logging::logger_t> log;
 
@@ -92,16 +111,8 @@ public:
     boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const std::vector<hpack::header_t>&, tuple_type&& args, upstream_type&& upstream)
     {
-        auto formatter = [] (const std::map<std::string, std::string>& data) -> std::string {
-            std::string result;
-            for(auto& pair: data) {
-                if(!result.empty()) {
-                    result += ", ";
-                }
-                result += pair.first + ":" + pair.second;
-            }
-            return result;
-        };
+        aux::formatter_t formatter;
+
         COCAINE_LOG_INFO(log, "spawn. {}, {}, {}, {}, {}",
                          boost::lexical_cast<std::string>(std::get<0>(args)),
                          std::get<1>(args),
@@ -115,9 +126,79 @@ public:
         upstream =  upstream.send<protocol::chunk>("CHUNK1");
         sleep(1);
         upstream = upstream.send<protocol::chunk>("CHUNK2");
+        sleep(1);
+        upstream = upstream.send<protocol::chunk>("CHUNK3");
+        sleep(1);
         upstream.send<protocol::choke>();
         COCAINE_LOG_INFO(log, "spawn. done");
         return boost::optional<std::shared_ptr<dispatch_type>>(std::make_shared<spawned_dispatch_t>());
+    }
+};
+
+struct metrics_slot_t:
+    public io::basic_slot<io::isolate::metrics>
+{
+public:
+    typedef typename io::aux::protocol_impl<typename io::event_traits<io::isolate::metrics>::upstream_type>::type protocol;
+    typedef typename io::basic_slot<io::isolate::metrics>::dispatch_type dispatch_type;
+
+    virtual
+    boost::optional<std::shared_ptr<dispatch_type>>
+    operator()(tuple_type&& args, upstream_type&& upstream)
+    {
+        return operator()({}, std::move(args), std::move(upstream));
+    }
+
+    virtual
+    boost::optional<std::shared_ptr<dispatch_type>>
+    operator()(const std::vector<hpack::header_t>&, tuple_type&& args, upstream_type&& upstream)
+    {
+        const auto &query = std::get<0>(args);
+        COCAINE_LOG_INFO(log, "metrics. {}", boost::lexical_cast<std::string>(query));
+
+        sleep(1);
+
+        rusage ru;
+        // note: values used as dummies and don't match real metrics meanings
+        if (getrusage(RUSAGE_THREAD, &ru)) {
+            // TODO: send errors?
+        }
+
+        dynamic_t::array_t metrics_array;
+        dynamic_t::object_t uuids;
+
+        for(const auto& uuid : query.as_object()["uuids"].as_array()) {
+                dynamic_t::object_t common;
+                dynamic_t::object_t metrics;
+
+                const auto total_time = ru.ru_utime.tv_sec + ru.ru_stime.tv_sec;
+
+                const auto cpu = total_time ?
+                    ru.ru_utime.tv_sec / total_time * 100 :
+                    0;
+
+                metrics["cpu.gauge"] = static_cast<std::uint64_t>(cpu % 100);
+
+                metrics["user_time.gauge"] = ru.ru_utime.tv_sec;
+                metrics["sys_time.gauge"] =  ru.ru_stime.tv_sec;
+
+                metrics["rss.gauge"] = ru.ru_maxrss;
+
+                metrics["ioread.counter"]  = ru.ru_inblock;
+                metrics["iowrite.counter"] = ru.ru_oublock;
+
+                common["common"] = metrics;
+                uuids[uuid.as_string()] = common;
+        }
+
+        dynamic_t::object_t answer;
+        answer["test_app"] = uuids;
+
+        upstream.send<protocol::value>(answer);
+
+        COCAINE_LOG_INFO(log, "metrics. done");
+
+        return boost::none;
     }
 };
 
@@ -133,8 +214,8 @@ public:
         log = context.log("isolate_mock");
         on<io::isolate::spool>(std::make_shared<spool_slot_t>());
         on<io::isolate::spawn>(std::make_shared<spawn_slot_t>());
-    }
-
+        on<io::isolate::metrics>(std::make_shared<metrics_slot_t>());
+     }
 
     virtual
     auto
@@ -145,7 +226,6 @@ public:
 private:
 };
 }}
-
 
 extern "C" {
 auto


### PR DESCRIPTION
Retrieve workers metrics from _Cocaine isolation daemon_ (aka [stout](https://github.com/noxiouz/stout)), register resulting signals within metrics service hub, show (some, probably after post-processing) in cocaine-tool info. Special attention should be paid to short living workers, their post-mortem metrics should be gathered and aggregated similarly.

#### TODO for first implementation:
 - [x] make metrics retrieving configurable
 - [x] correct per app aggregation for monotonically increasing values
 - [x] add protocol tests to isolation mock service
 - [x] signal in some form about workers metrics not updated for predefined period of time
 - [x] protocol encapsulated error messages processing 

#### Planned TODO (probably for separate pull request):
 - [ ] adjust and stabilize Cocaine <=> Isolation Daemon protocol: metrics names, types
 - [ ] make poll calls work in case of Isolation Daemon absence/disability (working, not tested)
 - [ ] check for possibility of external_t::metrics() concurrent access


Note that in current implementation isolation metrics polling is switched _off_ by default, to enable it set following parameters in `node` section of CocainRT configuration file:
```json
{
"services" : {
    "node" : {
       "args" : {
          "isolate_metrics:" : true,
          "isolate_metrics_poll_period_s" : 10
        }
    }
}
```