### PR TITLE
fix: dump from the app event loop

### DIFF
--- a/node/src/node/slave/machine.cpp
+++ b/node/src/node/slave/machine.cpp
@@ -335,7 +335,10 @@ machine_t::shutdown(std::error_code ec) {
     migrate(std::make_shared<inactive_t>(ec));
 
     if (ec && ec != error::overseer_shutdowning) {
-        dump();
+        auto self = shared_from_this();
+        loop.post([=] {
+            self->dump();
+        });
     }
 
     data.timers.apply([&](timers_map_t& timers) {


### PR DESCRIPTION
This allows to avoid race condition, while shutting down from the
network thread.