### PR TITLE
fix: do not clean core metafilter from map

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.13.0-alpha4) unstable; urgency=low
+
+  * Fixed: Do not drop core metafilter on cleanup from map,
+    allowing to control it from outside as it was before.
+
+ -- Anton Matveenko <antmat@me.com>  Tue, 04 Apr 2017 16:40:18 +0300
+
 cocaine-plugins (0.12.13.0-alpha3) unstable; urgency=low
 
   * Fixed: really prevent concurrent access to the stdout keeper in

--- a/logging/src/logging/metafilter.cpp
+++ b/logging/src/logging/metafilter.cpp
@@ -65,6 +65,7 @@ std::vector<filter_info_t>::iterator metafilter_t::remove_filter(std::vector<fil
 }
 
 bool metafilter_t::empty() const {
+    boost::shared_lock<boost::shared_mutex> guard(mutex);
     return filters.empty();
 }
 

--- a/logging/src/logging_v2.cpp
+++ b/logging/src/logging_v2.cpp
@@ -207,7 +207,10 @@ struct logging_v2_t::impl_t : public std::enable_shared_from_this<logging_v2_t::
                 std::vector<std::string> empty;
                 for(auto& mf_pair: metafilters) {
                     mf_pair.second->cleanup();
-                    if(mf_pair.second->empty()){
+                    // NOTE: core metafilter is stored by shared_ptr in filtering lambda and it is a special case
+                    // We can introduce something like 'need_cleanup' or 'useless' method to metafilter,
+                    // but for now it looks like an overkill, so we just check in cleanup if the name is 'core'
+                    if(mf_pair.second->empty() && mf_pair.first != core_key){
                         empty.push_back(mf_pair.first);
                     }
                 }


### PR DESCRIPTION
Deleting core metafilter from map drops out possibility to control it outside.