### PR TITLE
feat: zero-sized queue

### DIFF
--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -505,7 +505,7 @@ auto engine_t::rebalance_slaves() -> void {
                 if (load < vacant) {
                     lack = 0;
                 } else {
-                    lack = std::ceil(std::max(0, int(load) - int(vacant)) / static_cast<double>(profile.concurrency));
+                    lack = std::ceil((load - vacant) / static_cast<double>(profile.concurrency));
                 }
 
                 return pool.size() +  lack;

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -151,11 +151,11 @@ public:
     auto cancel() -> void;
 
 private:
-    /// Spawns a new slave using current manifest and profile.
+    /// Spawns a slave using current manifest and profile.
     auto spawn(pool_type& pool) -> void;
 
-    /// Spawns a new slave with the given id using current manifest and profile.
-    auto spawn(const id_t& id, pool_type& pool) -> void;
+    /// Spawns a slave with the given id using current manifest and profile.
+    auto spawn(id_t id, pool_type& pool) -> void;
 
     /// \warning must be called under the pool lock.
     auto assign(slave_t& slave, load_t& load) -> void;
@@ -170,6 +170,9 @@ private:
                       upstream<io::worker::control_tag>&& stream) -> std::shared_ptr<control_t>;
 
     auto on_slave_death(const std::error_code& ec, std::string uuid) -> void;
+
+    auto select_slave(pool_type& pool) -> boost::optional<slave_t&>;
+    auto select_slave(pool_type& pool, std::function<bool(const slave_t& slave)> filter) -> boost::optional<slave_t&>;
 
     auto rebalance_events() -> void;
 

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -174,6 +174,8 @@ private:
     auto select_slave(pool_type& pool) -> boost::optional<slave_t&>;
     auto select_slave(pool_type& pool, std::function<bool(const slave_t& slave)> filter) -> boost::optional<slave_t&>;
 
+    auto pool_pressure(pool_type& pool) -> std::size_t;
+
     auto rebalance_events() -> void;
     auto rebalance_events(pool_type& pool, queue_type& queue) -> void;
 

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -175,6 +175,7 @@ private:
     auto select_slave(pool_type& pool, std::function<bool(const slave_t& slave)> filter) -> boost::optional<slave_t&>;
 
     auto rebalance_events() -> void;
+    auto rebalance_events(pool_type& pool, queue_type& queue) -> void;
 
     auto rebalance_slaves() -> void;
 


### PR DESCRIPTION
This commit introduces zero-sized queue for App service. It allows to
immediately inject events without (almost) putting them into the queue.
Also if all slaves are busy the new policy will reject new events
without putting them into the queue.