### PR TITLE
Logging metrics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.13.1) unstable; urgency=low
+
+  * Feature: detailed metrics for logging::v2 service.
+
+ -- Anton Matveenko <antmat@me.com>  Mon, 12 Apr 2017 18:02:59 +0300
+
 cocaine-plugins (0.12.13.0-alpha6) unstable; urgency=low
 
   * Feature: trace_bit "traced" filter for logging::v2.

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -4,7 +4,7 @@ INCLUDE_DIRECTORIES(
     ${PROJECT_SOURCE_DIR}/unicorn/include)
 
 ADD_LIBRARY(logging MODULE
-        src/logging_v2.cpp
+    src/logging_v2.cpp
     src/module.cpp
     src/logging/filter.cpp
     src/logging/metafilter.cpp
@@ -15,6 +15,7 @@ TARGET_LINK_LIBRARIES(logging
     blackhole
     cocaine-core
     cocaine-io-util
+    metrics
 )
 
 SET_TARGET_PROPERTIES(logging PROPERTIES

--- a/logging/src/logging/metafilter.cpp
+++ b/logging/src/logging/metafilter.cpp
@@ -20,16 +20,41 @@
 
 #include "cocaine/logging/metafilter.hpp"
 
+#include <cocaine/context.hpp>
 #include <cocaine/logging.hpp>
 
 #include <blackhole/logger.hpp>
+
+#include <metrics/registry.hpp>
 
 #include <mutex>
 
 namespace cocaine {
 namespace logging {
 
-metafilter_t::metafilter_t(std::unique_ptr<logger_t> _logger) : logger(std::move(_logger)) {}
+metafilter_t::processed_t::processed_t(context_t& context, const std::string& name, const std::string& type) :
+    count(context.metrics_hub().counter<uint64_t>(format("logging.{}.{}.count", name, type))),
+    overall_count(context.metrics_hub().counter<uint64_t>(format("logging.{}.sum.count", name, type))),
+    count_since_change(context.metrics_hub().counter<uint64_t>(format("logging.{}.{}.count_since_change", name, type)))
+{
+}
+
+auto metafilter_t::processed_t::increment() -> void {
+    count->operator++();
+    overall_count->operator++();
+    count_since_change->operator++();
+}
+
+auto metafilter_t::processed_t::on_changed() -> void {
+    count_since_change->store(0ull);
+}
+
+metafilter_t::metafilter_t(context_t& context, std::string _name, std::unique_ptr<logger_t> _logger) :
+        name(std::move(_name)),
+        accepted(context, name, "accepted"),
+        rejected(context, name, "rejected"),
+        logger(std::move(_logger))
+{}
 
 void metafilter_t::add_filter(filter_info_t filter) {
     std::lock_guard<boost::shared_mutex> guard(mutex);
@@ -39,8 +64,8 @@ void metafilter_t::add_filter(filter_info_t filter) {
     });
     if(it == filters.end()) {
         filters.push_back(std::move(filter));
-        since_change_accepted_cnt.store(0);
-        since_change_rejected_cnt.store(0);
+        accepted.on_changed();
+        rejected.on_changed();
     }
 }
 
@@ -59,8 +84,8 @@ bool metafilter_t::remove_filter(filter_t::id_t filter_id) {
 }
 
 std::vector<filter_info_t>::iterator metafilter_t::remove_filter(std::vector<filter_info_t>::iterator it) {
-    since_change_accepted_cnt.store(0);
-    since_change_rejected_cnt.store(0);
+    accepted.on_changed();
+    rejected.on_changed();
     return filters.erase(it);
 }
 
@@ -91,11 +116,9 @@ filter_result_t metafilter_t::apply(blackhole::severity_t severity,
         cleanup();
     }
     if(result == filter_result_t::reject) {
-        overall_rejected_cnt++;
-        since_change_rejected_cnt++;
+        rejected.increment();
     } else {
-        overall_accepted_cnt++;
-        since_change_accepted_cnt++;
+        accepted.increment();
     }
 
     return result;


### PR DESCRIPTION
Detailed metafilters metrics now registered in context metrics hub for external usage.
Version bump inside (not alpha, according to cocaine-core version)!