### PR TITLE
Isolate workers metrics upd1

### DIFF
--- a/docker/isolate.cpp
+++ b/docker/isolate.cpp
@@ -287,7 +287,7 @@ docker_t::spawn(const std::string& path,
 }
 
 void
-docker_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t> handle) const
+docker_t::metrics(const std::vector<std::string>&, std::shared_ptr<api::metrics_handle_base_t> handle) const
 {
     return handle->on_data({});
 }

--- a/docker/isolate.hpp
+++ b/docker/isolate.hpp
@@ -25,6 +25,8 @@
 
 #include <cocaine/api/isolate.hpp>
 
+#include <vector>
+#include <string>
 #include <mutex>
 
 namespace cocaine { namespace isolate {
@@ -53,7 +55,7 @@ public:
 
     virtual
     void
-    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const;
+    metrics(const std::vector<std::string>& query, std::shared_ptr<api::metrics_handle_base_t> handle) const;
 
 private:
     context_t& m_context;

--- a/node/include/cocaine/api/isolate.hpp
+++ b/node/include/cocaine/api/isolate.hpp
@@ -24,6 +24,7 @@
 #include <cocaine/common.hpp>
 
 #include <cocaine/locked_ptr.hpp>
+#include <cocaine/idl/isolate.hpp>
 
 #include <map>
 #include <memory>
@@ -92,12 +93,14 @@ struct spawn_handle_base_t {
 };
 
 struct metrics_handle_base_t {
+    using response_type = cocaine::io::isolate::metrics::response_type;
+
     virtual
     ~metrics_handle_base_t() = default;
 
     virtual
     void
-    on_data(const dynamic_t& data) = 0;
+    on_data(const response_type& data) = 0;
 
     virtual
     void
@@ -124,7 +127,7 @@ struct isolate_t {
 
     virtual
     void
-    metrics(const dynamic_t& query,
+    metrics(const std::vector<std::string>& query,
         std::shared_ptr<api::metrics_handle_base_t> handler) const = 0;
 
     asio::io_service&

--- a/node/include/cocaine/detail/isolate/external.hpp
+++ b/node/include/cocaine/detail/isolate/external.hpp
@@ -24,6 +24,8 @@
 #include "cocaine/api/isolate.hpp"
 
 #include <memory>
+#include <vector>
+#include <string>
 
 namespace cocaine {
 namespace isolate {
@@ -51,7 +53,7 @@ public:
         -> std::unique_ptr<api::cancellation_t> override;
 
     auto
-    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const
+    metrics(const std::vector<std::string>& query, std::shared_ptr<api::metrics_handle_base_t> handle) const
         -> void override;
 };
 

--- a/node/include/cocaine/detail/isolate/process.hpp
+++ b/node/include/cocaine/detail/isolate/process.hpp
@@ -23,6 +23,9 @@
 
 #include "cocaine/api/isolate.hpp"
 
+#include <vector>
+#include <string>
+
 #include <cstdint>
 
 #include <boost/filesystem/path.hpp>
@@ -59,7 +62,7 @@ public:
         -> std::unique_ptr<api::cancellation_t> override;
 
     auto
-    metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const
+    metrics(const std::vector<std::string>& query, std::shared_ptr<api::metrics_handle_base_t> handle) const
         -> void override;
 };
 

--- a/node/include/cocaine/idl/isolate.hpp
+++ b/node/include/cocaine/idl/isolate.hpp
@@ -27,6 +27,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace cocaine { namespace io {
 
@@ -84,20 +85,32 @@ struct isolate {
     struct metrics {
         typedef isolate_tag tag;
 
+        using response_type =
+            std::map<
+                std::string, // worker id
+                std::map<
+                    std::string, // isolate
+                    std::map<
+                        std::string, // metric name
+                        dynamic_t
+                    >
+                >
+            >;
+
         static const char* alias() {
             return "metrics";
         }
 
         typedef boost::mpl::list<
             // Isolation daemon metrics query, in common cases - list of uuids.
-            dynamic_t
+            std::vector<std::string>
         > argument_type;
 
         typedef isolate_tag dispatch_type;
 
         typedef option_of<
             // Worker metrics grouped by uuids and application name.
-            dynamic_t
+            response_type
         >::tag upstream_type;
     };
 };

--- a/node/src/isolate/external.cpp
+++ b/node/src/isolate/external.cpp
@@ -15,6 +15,7 @@
 #include <cocaine/traits/dynamic.hpp>
 #include <cocaine/traits/endpoint.hpp>
 #include <cocaine/traits/vector.hpp>
+#include <cocaine/traits/map.hpp>
 
 #include <blackhole/logger.hpp>
 #include <asio/ip/tcp.hpp>
@@ -174,12 +175,12 @@ struct metrics_load_t {
     std::shared_ptr<external_t::inner_t> inner;
     std::shared_ptr<api::metrics_handle_base_t> handle;
 
-    dynamic_t query;
+    std::vector<std::string> query;
 
     io::upstream_ptr_t stream;
 
     metrics_load_t(std::shared_ptr<external_t::inner_t> _inner,
-                   const dynamic_t& _query,
+                   const std::vector<std::string>& _query,
                    std::shared_ptr<api::metrics_handle_base_t> _handle
     ) :
         inner(std::move(_inner)),
@@ -483,7 +484,7 @@ external_t::spawn(const std::string& path,
 }
 
 void
-external_t::metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const {
+external_t::metrics(const std::vector<std::string>& query, std::shared_ptr<api::metrics_handle_base_t> handle) const {
 
     auto load = std::make_shared<metrics_load_t>(inner, query, handle);
 

--- a/node/src/isolate/external.cpp
+++ b/node/src/isolate/external.cpp
@@ -482,9 +482,6 @@ external_t::spawn(const std::string& path,
     return std::unique_ptr<api::cancellation_t>(new api::cancellation_wrapper(load));
 }
 
-
-// TODO: is concurrency supported?
-// it seems that spool and spawn concurrent access is ensured by state machine.
 void
 external_t::metrics(const dynamic_t& query, std::shared_ptr<api::metrics_handle_base_t> handle) const {
 

--- a/node/src/isolate/process.cpp
+++ b/node/src/isolate/process.cpp
@@ -433,7 +433,7 @@ process_t::spawn(const std::string& path,
 }
 
 void
-process_t::metrics(const dynamic_t&, std::shared_ptr<api::metrics_handle_base_t> handle) const
+process_t::metrics(const std::vector<std::string>&, std::shared_ptr<api::metrics_handle_base_t> handle) const
 {
     assert(handle);
     return handle->on_data({});

--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -64,27 +64,6 @@ engine_t::engine_t(context_t& context,
     stats(context, manifest_.name, std::chrono::seconds(2))
 {
     attach_pool_observer(std::move(observer));
-
-    const auto isolate = context.repository().get<api::isolate_t>(
-        profile.isolate.type,
-        context,
-        *loop,
-        manifest_.name,
-        profile.isolate.type,
-        profile.isolate.args);
-
-    try {
-        metrics_retriever = metrics_retriever_t::make_and_ignite(
-            context,
-            manifest_.name,
-            isolate,
-            *this,
-            *loop,
-            observers);
-    } catch(const error::repository_errors& err) {
-        COCAINE_LOG_WARNING(log, "failed to init metrics poll sequence, error {}", err);
-    }
-
     COCAINE_LOG_DEBUG(log, "overseer has been initialized");
 }
 
@@ -104,16 +83,43 @@ auto engine_t::active_workers() const -> std::uint32_t {
     });
 }
 
-auto engine_t::ids_of_pool() const -> std::vector<std::string> {
+auto engine_t::pooled_workers_ids() const -> std::vector<std::string> {
     using boost::adaptors::map_keys;
 
-    return pool.apply([](const pool_type& pool){
-        std::vector<std::string> ids;
+    std::vector<std::string> ids;
+    return pool.apply([&](const pool_type& pool){
         ids.reserve(pool.size());
-
         boost::copy(pool | map_keys, std::back_inserter(ids));
         return ids;
     });
+}
+
+auto
+engine_t::start_isolate_metrics_poll() -> void
+{
+    auto isolate = profile_.apply([&](const profile_t& profile) {
+        return context.repository().get<api::isolate_t>(
+        profile.isolate.type,
+        context,
+        *loop,
+        manifest_.name,
+        profile.isolate.type,
+        profile.isolate.args);
+    });
+
+    metrics_retriever = metrics_retriever_t::make_and_ignite(
+        context,
+        manifest_.name,
+        isolate,
+        shared_from_this(),
+        *loop,
+        observers);
+}
+
+auto
+engine_t::stop_isolate_metrics_poll() -> void
+{
+    metrics_retriever.reset();
 }
 
 manifest_t

--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -78,7 +78,7 @@ engine_t::engine_t(context_t& context,
             context,
             manifest_.name,
             isolate,
-            pool,
+            *this,
             *loop,
             observers);
     } catch(const error::repository_errors& err) {
@@ -101,6 +101,18 @@ auto engine_t::active_workers() const -> std::uint32_t {
             }
         }
         return active;
+    });
+}
+
+auto engine_t::ids_of_pool() const -> std::vector<std::string> {
+    using boost::adaptors::map_keys;
+
+    return pool.apply([](const pool_type& pool){
+        std::vector<std::string> ids;
+        ids.reserve(pool.size());
+
+        boost::copy(pool | map_keys, std::back_inserter(ids));
+        return ids;
     });
 }
 

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -157,6 +157,8 @@ public:
     auto cancel() -> void;
 
     auto attach_pool_observer(std::shared_ptr<pool_observer> observer) -> void;
+
+    auto ids_of_pool() const -> std::vector<std::string>;
 private:
     /// Spawns a slave using current manifest and profile.
     auto spawn(pool_type& pool) -> void;

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -158,7 +158,15 @@ public:
 
     auto attach_pool_observer(std::shared_ptr<pool_observer> observer) -> void;
 
-    auto ids_of_pool() const -> std::vector<std::string>;
+    // TODO: may be some filter someday ('active', 'sealed', etc), + use std::set
+    auto pooled_workers_ids() const -> std::vector<std::string>;
+
+    // Moved from ctor, need to start poll sequence explicitly as in most general
+    // case we can't call engine_t::shared_from_this() (needed in poll object
+    // construction) from engine_t::ctor. stop_isolate_metrics_poll is
+    // currently unused, defined for symmetry.
+    auto start_isolate_metrics_poll() -> void;
+    auto stop_isolate_metrics_poll() -> void;
 private:
     /// Spawns a slave using current manifest and profile.
     auto spawn(pool_type& pool) -> void;

--- a/node/src/node/isometrics.cpp
+++ b/node/src/node/isometrics.cpp
@@ -1,6 +1,8 @@
 #include <tuple>
 #include <cassert>
 #include <unordered_map>
+#include <vector>
+#include <string>
 
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
@@ -16,7 +18,7 @@
 // TODO: deprecated
 #ifdef ISOMETRICS_DEBUG
 #define dbg(msg) std::cerr << msg << '\n'
-#define DBG_DUMP_UUIDS(os, logo, container) aux::dump_uuids(os, logo, container)
+#define DBG_DUMP_UUIDS(os, logo, container) detail::dump_uuids(os, logo, container)
 #else
 #define dbg(msg)
 #define DBG_DUMP_UUIDS(os, logo, container)
@@ -58,7 +60,6 @@ namespace conf {
         {"iowrite", aggregate_t::aggregate},
 
         // TODO: network stats
-
     };
 }
 
@@ -84,8 +85,8 @@ namespace detail {
     auto
     dump_uuids(std::ostream& os, const std::string& logo, const Container& arr) -> void {
         os << logo << " size " << arr.size() << '\n';
-        for(const auto& uuid : arr) {
-            os << "\tuuid: " << uuid_value(uuid) << '\n';
+        for(const auto& id : arr) {
+            os << "\tuuid: " << uuid_value(id) << '\n';
         }
     }
 
@@ -173,10 +174,12 @@ worker_metrics_t::assign(metrics_aggregate_proxy_t&& proxy) -> void {
     }
 }
 
-// TODO: error messages processing
 struct response_processor_t {
     using stats_table_type = metrics_retriever_t::stats_table_type;
     using faded_update_mapping_type = std::unordered_map<std::string, std::chrono::seconds>;
+
+    using response_type = api::metrics_handle_base_t::response_type;
+    using metrics_mapping_type = response_type::mapped_type::mapped_type;
 
     struct error_t {
         long code;
@@ -188,77 +191,64 @@ struct response_processor_t {
     {}
 
     auto
-    operator()(context_t& ctx, const dynamic_t& response, stats_table_type& stats_table,
+    operator()(context_t& ctx, const response_type& response, stats_table_type& stats_table,
         const std::chrono::seconds& faded_timeout) -> size_t
     {
         return process(ctx, response, stats_table, faded_timeout);
     }
 
     auto
-    process(context_t& ctx, const dynamic_t& response, stats_table_type& stats_table,
+    process(context_t& ctx, const response_type& response, stats_table_type& stats_table,
        const std::chrono::seconds& faded_timeout) -> size_t
     {
-        const auto apps = response.as_object();
+        auto ids_processed = size_t{};
 
-        auto uuids_processed = size_t{};
+        for(const auto& worker : response) {
+            const auto& id = worker.first;
+            const auto& isolates = worker.second;
 
-        for(const auto& app : apps) {
+            if (id.empty()) {
+                dbg("[response] 'id' value is empty, ignoring");
+                continue;
+            }
 
-            // TODO: restore app_name assertion check
-            //
-            // strictly, we should have one app at all within current protocol
-            // if (app_name != app.first) {
-            //     dbg("JSON app is " << app.first);
-            //     continue;
-            // }
-
-            const auto uuids = app.second.as_object();
             const auto now = worker_metrics_t::clock_type::now();
 
-            for(const auto& item : uuids) {
-                const auto& uuid = item.first;
-                const auto& metrics = item.second.as_object();
+            for(const auto& isolate: isolates) {
+                const auto& isolate_type = isolate.first;
+                const auto& metrics      = isolate.second;
 
-                if (uuid.empty()) {
-                    dbg("[response] 'uuid' value is empty, ignoring");
-                    continue;
-                }
-
-                if (uuid == std::string("error")) {
-                    parse_error_record(metrics);
-                    continue;
-                }
-
-                auto stat_it = stats_table.find(uuid);
+                auto stat_it = stats_table.find(id);
                 if (stat_it == std::end(stats_table)) {
-                    // If isolate daemon sends us uuid we don't know about,
+                    // If isolate daemon sends us id we don't know about,
                     // add it to the stats (monitoring) table. If it was send by error, it
                     // would be removed from request list and from stats table
                     // on next poll iteration preparation.
-                    dbg("[response] inserting new metrics record with uuid" << uuid);
-                    std::tie(stat_it, std::ignore) = stats_table.emplace(uuid, worker_metrics_t{ctx, app_name, uuid});
+                    dbg("[response] inserting new metrics record with id " << id);
+                    std::tie(stat_it, std::ignore) = stats_table.emplace(id, worker_metrics_t{ctx, app_name, id});
                 }
 
-                auto common_it = metrics.find("common");
-                if (common_it == std::end(metrics)) {
-                    dbg("[response] no `common` section");
+                if (isolate_type == std::string("common") ||
+                    isolate_type == std::string("mock_isolate"))
+                {
+                    const auto& updated_count = this->fill_metrics(metrics, stat_it->second.common_counters);
+
+                    if (updated_count) {
+                        stat_it->second.update_stamp = now;
+                    } else {
+                        const auto& update_span = now - stat_it->second.update_stamp;
+                        if (update_span > faded_timeout) {
+                            faded.emplace(id, std::chrono::duration_cast<std::chrono::seconds>(update_span));
+                        }
+                    }
+                } else if (isolate_type == std::string("error")) {
+                    parse_error_record(metrics);
                     continue;
                 }
-
-                const auto& updated_count = this->fill_metrics(common_it->second.as_object(), stat_it->second.common_counters);
-
-                if (updated_count) {
-                    stat_it->second.update_stamp = now;
-                } else {
-                    const auto& update_span = now - stat_it->second.update_stamp;
-                    if (update_span > faded_timeout) {
-                        faded.emplace(uuid, std::chrono::duration_cast<std::chrono::seconds>(update_span));
-                    }
-                }
             }
-        }
+        } // for worker
 
-        return uuids_processed;
+        return ids_processed;
     }
 
     auto
@@ -289,27 +279,36 @@ struct response_processor_t {
 private:
 
     auto
-    parse_error_record(const dynamic_t::object_t& metrics) -> void {
-        const auto& error_message = metrics.at("error.message", "none").as_string();
-        const auto& error_code    = metrics.at("error.code", 0).as_int();
+    parse_error_record(const metrics_mapping_type& error_record) -> void {
+        auto error_message = std::string{};
+        auto error_code = int{};
 
-        isolate_errors.emplace_back(error_t{error_code, error_message});
+        try {
+            auto it = error_record.find("what");
+            if (it != std::end(error_record)) {
+                error_message = it->second.as_string();
+            }
 
-        dbg("[response] got an error: " << error_message << " code: " << error_code);
+            it = error_record.find("code");
+            if (it != std::end(error_record)) {
+                error_code = it->second.as_int();
+            }
+
+            isolate_errors.push_back(error_t{error_code, error_message});
+            dbg("[response] got an error message: " << error_message << " code: " << error_code);
+        } catch (const boost::bad_get& bg) {
+            // ignore
+            dbg("[response] error message parsing error: " << error_message << " code: " << error_code);
+        }
     }
 
     auto
-    fill_metrics(const dynamic_t::object_t& metrics, worker_metrics_t::counters_table_type& result) -> size_t {
-
+    fill_metrics(const metrics_mapping_type& metrics, worker_metrics_t::counters_table_type& result) -> size_t {
         auto updated = size_t{};
-
-        if (metrics.count("error.message")) {
-            parse_error_record(metrics);
-            return updated;
-        }
 
         for(const auto& metric : metrics) {
             const auto& name = metric.first;
+            const auto& value = metric.second;
 
             dbg("[response] metrics name: " << name);
 
@@ -322,28 +321,31 @@ private:
                 continue;
             }
 
+            auto r = result.find(nm);
+            if (r == std::end(result)) {
+                continue;
+            }
+
+            // we are interested in this metrics, its name was registered
+            dbg("[response] found metrics record for " << nm << ", updating...");
+
             try {
-                auto r = result.find(nm);
-                if (r != std::end(result)) {
-                    // we are interested in this metrics, its name was registered
-                    dbg("[response] found metrics record for " << nm << ", updating...");
+                auto& record = r->second;
+                const auto& incoming_value = value.as_uint();
 
-                    auto& record = r->second;
-                    const auto& incoming_value = metric.second.as_uint();
+                dbg("[response] incoming_value " << incoming_value);
 
-                    if (record.type == aggregate_t::aggregate) {
-                        const auto& current = record.value->load();
-                        if (incoming_value >= current) {
-                            record.delta = incoming_value - current;
-                        } // else: client misbehavior, shouldn't try to store negative deltas
-                    }
-
-                    record.value->store(incoming_value);
-                    ++updated;
+                if (record.type == aggregate_t::aggregate) {
+                    const auto& current = record.value->load();
+                    if (incoming_value >= current) {
+                        record.delta = incoming_value - current;
+                    } // else: client misbehavior, shouldn't try to store negative deltas
                 }
 
-            } catch (const boost::bad_get& e) {
-                dbg("[response] parsing exception: " << e.what());
+                record.value->store(incoming_value);
+                ++updated;
+            } catch (const boost::bad_get& err) {
+                dbg("[response] exception " << err.what());
                 continue;
             }
         } // for each metric
@@ -401,7 +403,7 @@ metrics_retriever_t::self_metrics_t::self_metrics_t(context_t& ctx, const std::s
    uuids_requested{detail::make_uint_counter(ctx, pfx, "uuids.requested")},
    uuids_recieved{detail::make_uint_counter(ctx, pfx, "uuids.recieved")},
    requests_send{detail::make_uint_counter(ctx, pfx, "requests")},
-   requests_passed{detail::make_uint_counter(ctx, pfx, "requests.passed")},
+   empty_requests{detail::make_uint_counter(ctx, pfx, "empty.requests")},
    responses_received{detail::make_uint_counter(ctx, pfx, "responses")},
    receive_errors{detail::make_uint_counter(ctx, pfx, "recieve.errors")},
    posmortem_queue_size{detail::make_uint_counter(ctx, pfx, "postmortem.queue.size")}
@@ -475,8 +477,8 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     });
 #endif
 
-    dynamic_t::array_t query_array;
-    query_array.reserve(alive_uuids.size() + purgatory->size());
+    std::vector<std::string> query;
+    query.reserve(alive_uuids.size() + purgatory->size());
 
     // Note: it is promised by devs that active list should be quite
     // small ~ hundreds of workers, so it seems reasonable to pay a little for
@@ -485,25 +487,25 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     boost::sort(alive_uuids);
 
     purgatory.apply([&](purgatory_pot_type& pot) {
-        boost::set_union(alive_uuids, pot, std::back_inserter(query_array));
+        boost::set_union(alive_uuids, pot, std::back_inserter(query));
         pot.clear();
         self_metrics.posmortem_queue_size->store(0);
     });
 
-    DBG_DUMP_UUIDS(std::cerr, "query array", query_array);
-
 #if 0
-    query_array.emplace_back("DEADBEEF-0001-0001-0001-000000000001");
-    query_array.emplace_back("C0C0C042-0042-0042-0042-000000000042");
+    query.emplace_back("DEADBEEF-0001-0001-0001-000000000001");
+    query.emplace_back("C0C0C042-0042-0042-0042-000000000042");
 #endif
 
+    DBG_DUMP_UUIDS(std::cerr, "query array", query);
+
     // TODO: should we send empty query as some kind of heartbeat?
-    if (query_array.empty()) {
-        self_metrics.requests_passed->fetch_add(1);
-    } else {
-        isolate->metrics(query_array, std::make_shared<metrics_handle_t>(shared_from_this()));
-        self_metrics.requests_send->fetch_add(1);
+    if (query.empty()) {
+        self_metrics.empty_requests->fetch_add(1);
     }
+
+    isolate->metrics(query, std::make_shared<metrics_handle_t>(shared_from_this()));
+    self_metrics.requests_send->fetch_add(1);
 
     // At this point query is posted and we have gathered uuids of available
     // (alived, pooled) workers and dead recently workers, so we can clear
@@ -512,8 +514,8 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     preserved_metrics.reserve(metrics->size());
 
     metrics.apply([&](stats_table_type& table) {
-        for(const auto to_preserve : query_array) {
-            const auto it = table.find(to_preserve.as_string());
+        for(const auto& to_preserve : query) {
+            const auto it = table.find(to_preserve);
 
             if (it != std::end(table)) {
                 preserved_metrics.emplace(std::move(*it));
@@ -525,7 +527,7 @@ metrics_retriever_t::poll_metrics(const std::error_code& ec) -> void {
     });
 
     // Update self stat
-    self_metrics.uuids_requested->fetch_add(query_array.size());
+    self_metrics.uuids_requested->fetch_add(query.size());
 
     ignite_poll();
 }
@@ -538,14 +540,12 @@ metrics_retriever_t::make_observer() -> std::shared_ptr<pool_observer> {
 //// metrics_handle_t //////////////////////////////////////////////////////////
 
 auto
-metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
+metrics_retriever_t::metrics_handle_t::on_data(const response_type& data) -> void {
     using namespace boost::adaptors;
 
     assert(parent);
 
     dbg("metrics_handle_t:::on_data");
-    dbg("[response] get json: " << boost::lexical_cast<std::string>(data) << '\n');
-
     COCAINE_LOG_DEBUG(parent->log, "processing isolation metrics response");
 
     const auto faded_timeout = std::chrono::seconds(parent->poll_interval.total_seconds() * conf::missed_updates_times);
@@ -581,10 +581,10 @@ metrics_retriever_t::metrics_handle_t::on_data(const dynamic_t& data) -> void {
     }
 
     for(const auto& faded : processor.faded_updates()) {
-        const auto& uuid = faded.first;
+        const auto& id = faded.first;
         const auto& duration = faded.second;
 
-        COCAINE_LOG_WARNING(parent->log, "no isolate metrics for active worker {} for {} second(s)", uuid, duration.count());
+        COCAINE_LOG_WARNING(parent->log, "no isolate metrics for active worker {} for {} second(s)", id, duration.count());
     }
 }
 

--- a/node/src/node/isometrics.hpp
+++ b/node/src/node/isometrics.hpp
@@ -120,7 +120,7 @@ private:
         metrics::shared_metric<std::atomic<std::uint64_t>> uuids_requested;
         metrics::shared_metric<std::atomic<std::uint64_t>> uuids_recieved;
         metrics::shared_metric<std::atomic<std::uint64_t>> requests_send;
-        metrics::shared_metric<std::atomic<std::uint64_t>> requests_passed;
+        metrics::shared_metric<std::atomic<std::uint64_t>> empty_requests;
         metrics::shared_metric<std::atomic<std::uint64_t>> responses_received;
         metrics::shared_metric<std::atomic<std::uint64_t>> receive_errors;
         metrics::shared_metric<std::atomic<std::uint64_t>> posmortem_queue_size;
@@ -195,12 +195,14 @@ private:
     // TODO: wip, possibility of redesign
     struct metrics_handle_t : public api::metrics_handle_base_t
     {
+        using response_type = api::metrics_handle_base_t::response_type;
+
         metrics_handle_t(std::shared_ptr<metrics_retriever_t> parent) :
             parent{parent}
         {}
 
         auto
-        on_data(const dynamic_t& data) -> void override;
+        on_data(const response_type& data) -> void override;
 
         auto
         on_error(const std::error_code&, const std::string& what) -> void override;

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -22,7 +22,16 @@ overseer_t::overseer_t(context_t& context,
                        profile_t profile,
                        std::shared_ptr<pool_observer> observer,
                        std::shared_ptr<asio::io_service> loop)
-    : engine(std::make_shared<engine_t>(context, manifest, profile, observer, loop)) {}
+    : engine(std::make_shared<engine_t>(context, manifest, profile, observer, loop))
+{
+    try {
+        engine->start_isolate_metrics_poll();
+    } catch(const error_t& err) {
+        COCAINE_LOG_WARNING(engine->log,
+            "failed to init metrics poll sequence: error code {}, reason {}",
+            err.code(), err.what());
+    }
+}
 
 overseer_t::~overseer_t() {
     COCAINE_LOG_DEBUG(engine->log, "overseer is processing terminate request");


### PR DESCRIPTION
- use weak_ptr(engine_t) as reference from metrics_retriever_t to avoid SIGSEGV in poll callback.
- start poll sequence explicitly by `engine_t::start_isolate_metrics_poll`, as we should separate share_ptr<engine_t> creation and  engine_t::shared_from_this() call.
- refactor out profile_t synchronized usage in engine_t, as former implementation leads to deadlocks.
- remade error messages (exception) in  `metrics_retriever_t::make_and_ignite(...)`.
- refactoring of isolate metrics protocol 