### PR TITLE
fix: remove metrics explicitly during restart

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: cmake,
  libnl-3-dev, libnl-genl-3-dev, libcurl4-openssl-dev (>= 7.22.0),
  libzookeeper-mt-dev,
  blackhole-migration-dev (>= 1.0.0-1),
- metics3-dev (>= 3.1.0),
+ metrics3-dev (>= 3.1.0),
  libpqxx-dev
 # mongodb-dev (<< 1:2.5.0), mongodb-dev (>= 1:2.4.9)
 Standards-Version: 3.9.3

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: cmake,
  libnl-3-dev, libnl-genl-3-dev, libcurl4-openssl-dev (>= 7.22.0),
  libzookeeper-mt-dev,
  blackhole-migration-dev (>= 1.0.0-1),
+ metics3-dev (>= 3.1.0),
  libpqxx-dev
 # mongodb-dev (<< 1:2.5.0), mongodb-dev (>= 1:2.4.9)
 Standards-Version: 3.9.3
@@ -148,7 +149,8 @@ Description: Cocaine - v2 logging service (debug symbols)
 Package: libcocaine-plugin-node3
 Architecture: any
 Section: libs
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends},
+ libmetics3 (>= 3.1.0)
 Description: Cocaine - Node Service
  Node service for Cocaine.
 

--- a/node/include/cocaine/detail/service/node/stats.hpp
+++ b/node/include/cocaine/detail/service/node/stats.hpp
@@ -42,7 +42,8 @@ struct stats_t {
     metrics::shared_metric<metrics::timer<metrics::accumulator::decaying::exponentially_t>> timer;
 
     stats_t(context_t& context, const std::string& name, std::chrono::high_resolution_clock::duration interval);
-    ~stats_t();
+
+    auto deregister() -> void;
 };
 
 }  // namespace cocaine

--- a/node/include/cocaine/detail/service/node/stats.hpp
+++ b/node/include/cocaine/detail/service/node/stats.hpp
@@ -14,6 +14,9 @@
 namespace cocaine {
 
 struct stats_t {
+    std::string name;
+    metrics::registry_t& metrics_hub;
+
     struct {
         /// Number of requests, that are pushed into the queue.
         metrics::shared_metric<std::atomic<std::int64_t>> accepted;
@@ -39,6 +42,7 @@ struct stats_t {
     metrics::shared_metric<metrics::timer<metrics::accumulator::decaying::exponentially_t>> timer;
 
     stats_t(context_t& context, const std::string& name, std::chrono::high_resolution_clock::duration interval);
+    ~stats_t();
 };
 
 }  // namespace cocaine

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -8,6 +8,7 @@
 #include "cocaine/service/node/slave/id.hpp"
 
 #include "cocaine/detail/service/node/slave.hpp"
+#include "cocaine/detail/service/node/stats.hpp"
 
 #include "engine.hpp"
 #include "pool_observer.hpp"
@@ -26,6 +27,7 @@ overseer_t::overseer_t(context_t& context,
 overseer_t::~overseer_t() {
     COCAINE_LOG_DEBUG(engine->log, "overseer is processing terminate request");
 
+    engine->stats.deregister();
     engine->stopped = true;
     engine->control_population(0);
     engine->pool->clear();

--- a/node/src/node/stats.cpp
+++ b/node/src/node/stats.cpp
@@ -24,7 +24,7 @@ const char name_timings[] = "{}.timings";
 
 stats_t::stats_t(context_t& context, const std::string& name, std::chrono::high_resolution_clock::duration interval):
     name{name},
-    metrics_hub{context.metrics_hub()},
+    metrics_hub(context.metrics_hub()),
     requests{
         metrics_hub.counter<std::int64_t>(cocaine::format(name_requests_accepted, name)),
         metrics_hub.counter<std::int64_t>(cocaine::format(name_requests_rejected, name))

--- a/node/src/node/stats.cpp
+++ b/node/src/node/stats.cpp
@@ -10,39 +10,51 @@
 
 namespace cocaine {
 
+namespace {
+
+const char name_requests_accepted[] = "{}.requests.accepted";
+const char name_requests_rejected[] = "{}.requests.rejected";
+const char name_slaves_spawned[] = "{}.slaves.spawned";
+const char name_slaves_crashed[] = "{}.slaves.crashed";
+const char name_rate[] = "{}.rate";
+const char name_queue_depth_average[] = "{}.queue.depth_average";
+const char name_timings[] = "{}.timings";
+
+} // namespace
+
 stats_t::stats_t(context_t& context, const std::string& name, std::chrono::high_resolution_clock::duration interval):
     name{name},
     metrics_hub{context.metrics_hub()},
     requests{
-        metrics_hub.counter<std::int64_t>(cocaine::format("{}.requests.accepted", name)),
-        metrics_hub.counter<std::int64_t>(cocaine::format("{}.requests.rejected", name))
+        metrics_hub.counter<std::int64_t>(cocaine::format(name_requests_accepted, name)),
+        metrics_hub.counter<std::int64_t>(cocaine::format(name_requests_rejected, name))
     },
     slaves{
-        metrics_hub.counter<std::int64_t>(cocaine::format("{}.slaves.spawned", name)),
-        metrics_hub.counter<std::int64_t>(cocaine::format("{}.slaves.crashed", name))
+        metrics_hub.counter<std::int64_t>(cocaine::format(name_slaves_spawned, name)),
+        metrics_hub.counter<std::int64_t>(cocaine::format(name_slaves_crashed, name))
     },
-    meter(metrics_hub.meter(cocaine::format("{}.rate", name))),
+    meter(metrics_hub.meter(cocaine::format(name_rate, name))),
     queue_depth(std::make_shared<metrics::usts::ewma_t>(interval)),
     queue_depth_gauge(metrics_hub
         .register_gauge<double>(
-            cocaine::format("{}.queue.depth_average", name),
+            cocaine::format(name_queue_depth_average, name),
             {},
             std::bind(&metrics::usts::ewma_t::get, queue_depth)
         )
     ),
-    timer(metrics_hub.timer<metrics::accumulator::decaying::exponentially_t>(cocaine::format("{}.timings", name)))
+    timer(metrics_hub.timer<metrics::accumulator::decaying::exponentially_t>(cocaine::format(name_timings, name)))
 {
     queue_depth->add(0);
 }
 
-stats_t::~stats_t() {
-    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format("{}.requests.accepted", name), {});
-    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format("{}.requests.rejected", name), {});
-    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format("{}.slaves.spawned", name), {});
-    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format("{}.slaves.crashed", name), {});
-    metrics_hub.remove<metrics::meter_t>(cocaine::format("{}.rate", name), {});
-    metrics_hub.remove<metrics::gauge<double>>(cocaine::format("{}.queue.depth_average", name), {});
-    metrics_hub.remove<metrics::timer<metrics::accumulator::decaying::exponentially_t>>(cocaine::format("{}.timings", name), {});
+auto stats_t::deregister() -> void {
+    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format(name_requests_accepted, name), {});
+    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format(name_requests_rejected, name), {});
+    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format(name_slaves_spawned, name), {});
+    metrics_hub.remove<std::atomic<std::int64_t>>(cocaine::format(name_slaves_crashed, name), {});
+    metrics_hub.remove<metrics::meter_t>(cocaine::format(name_rate, name), {});
+    metrics_hub.remove<metrics::gauge<double>>(cocaine::format(name_queue_depth_average, name), {});
+    metrics_hub.remove<metrics::timer<metrics::accumulator::decaying::exponentially_t>>(cocaine::format(name_timings, name), {});
 }
 
-}  // namespace cocaine
+} // namespace cocaine


### PR DESCRIPTION
This explicitly drops metrics from the registry, not allowing readers to prolong their lifetime. Ideally it can be resolved by splitting readers and writers, but it breaks API, so let it be in the future releases.