### PR TITLE
New elliptic client

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.14.12) unstable; urgency=low
+
+  * Fixed: deadlock in vicodyn due to cyclic detach.
+  * Refactored: debian dep on new elliptics-client package.
+
+ -- Anton Matveenko <antmat@me.com>  Tue, 04 Aug 2017 12:51:26 +0300
+
 cocaine-plugins (0.12.14.11) unstable; urgency=low
 
   * Fixed: vicodyn now do not request dispatch name from the wrong map.

--- a/debian/control
+++ b/debian/control
@@ -305,7 +305,7 @@ Description: Vicodyn gateway (dev files)
 
 Package: libcocaine-plugin-elliptics3
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, elliptics-client2.27 (>= 2.27.2.5), libcocaine-core3 (>= 0.12.14)
+Depends: ${shlibs:Depends}, ${misc:Depends}, elliptics-client(>=2.27.2.5) | elliptics-client2.27(>= 2.27.2.5), libcocaine-core3 (>= 0.12.14)
 Conflicts: libcocaine-plugin-elliptics
 Replaces: libcocaine-plugin-elliptics
 Description: Distributed hash table storage (cocaine plugin)

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,11 @@
 #export DH_VERBOSE=1
 export DEB_BUILD_OPTIONS=parallel=$(shell grep -c ^processor /proc/cpuinfo)
 
+# Remove elliptics-client packages from `${shlibs:Depends}` substvar as these
+# packages are explicitly specified in debian/control
+override_dh_shlibdeps:
+	dh_shlibdeps -- -xelliptics-client2.27 -xelliptics-client
+
 override_dh_auto_configure:
 	dh_auto_configure -- -DCOCAINE_ALLOW_CGROUPS=OFF -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_CXX_FLAGS="-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security"
 


### PR DESCRIPTION
elliptics-client2.27 is going to be renamed back to elliptics-client, so we need to support migration process
@3Hren PTAL