### PR TITLE
Unicorn dead lock fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.14.14) unstable; urgency=low
+
+  * Fixed: unicorn dead lock during watch cancellation.
+
+ -- Anton Matveenko <antmat@me.com>  Mon, 07 Aug 2017 13:03:26 +0300
+
 cocaine-plugins (0.12.14.13) unstable; urgency=low
 
   * Fixed: unicorn discovery do not drop nodes on disconnection.

--- a/unicorn/src/zookeeper/connection.cpp
+++ b/unicorn/src/zookeeper/connection.cpp
@@ -253,10 +253,12 @@ auto connection_t::cancel_watches() -> void {
     watchers.apply([&](watchers_t& watchers) mutable {
         watchers_for_cancellation.swap(watchers);
     });
-    watch_reply_t reply {ZOO_SESSION_EVENT, ZOO_EXPIRED_SESSION_STATE, ""};
-    for(auto& w: watchers_for_cancellation) {
-        w.second->operator()(reply);
-    }
+    executor->spawn([=]{
+        watch_reply_t reply {ZOO_SESSION_EVENT, ZOO_EXPIRED_SESSION_STATE, ""};
+        for(auto& w: watchers_for_cancellation) {
+            w.second->operator()(reply);
+        }
+    });
 }
 
 auto connection_t::check_rc(int rc) -> void {


### PR DESCRIPTION
defer watch cancellation in event loop to prevent dead lock
@3Hren PTAL