### PR TITLE
fix: avoid access for `dead` context_t::logger_t in uniresis::updater_t

### DIFF
--- a/uniresis/include/cocaine/service/uniresis.hpp
+++ b/uniresis/include/cocaine/service/uniresis.hpp
@@ -5,6 +5,7 @@
 #include <cocaine/api/service.hpp>
 #include <cocaine/idl/context.hpp>
 #include <cocaine/rpc/dispatch.hpp>
+#include <cocaine/executor/asio.hpp>
 
 #include "cocaine/idl/uniresis.hpp"
 #include "cocaine/uniresis/resources.hpp"
@@ -19,6 +20,10 @@ class uniresis_t : public api::service_t, public dispatch<io::uniresis_tag> {
     uniresis::resources_t resources;
     std::shared_ptr<updater_t> updater;
     std::shared_ptr<logging::logger_t> log;
+
+    // Note that executor `must die` before updater as it contain io loop for
+    // updater's inner timer.
+    std::shared_ptr<executor::owning_asio_t> executor;
 
     // Slot for context signals.
     std::shared_ptr<dispatch<io::context_tag>> signal;

--- a/uniresis/include/cocaine/service/uniresis.hpp
+++ b/uniresis/include/cocaine/service/uniresis.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <cocaine/api/service.hpp>
+#include <cocaine/idl/context.hpp>
 #include <cocaine/rpc/dispatch.hpp>
 
 #include "cocaine/idl/uniresis.hpp"
@@ -19,6 +20,8 @@ class uniresis_t : public api::service_t, public dispatch<io::uniresis_tag> {
     std::shared_ptr<updater_t> updater;
     std::shared_ptr<logging::logger_t> log;
 
+    // Slot for context signals.
+    std::shared_ptr<dispatch<io::context_tag>> signal;
 public:
     uniresis_t(context_t& context, asio::io_service& loop, const std::string& name, const dynamic_t& args);
 
@@ -26,6 +29,8 @@ public:
     prototype() -> io::basic_dispatch_t& {
         return *this;
     }
+private:
+    auto on_context_shutdown() -> void;
 };
 
 } // namespace uniresis

--- a/uniresis/include/cocaine/service/uniresis.hpp
+++ b/uniresis/include/cocaine/service/uniresis.hpp
@@ -21,7 +21,7 @@ class uniresis_t : public api::service_t, public dispatch<io::uniresis_tag> {
     std::shared_ptr<updater_t> updater;
     std::shared_ptr<logging::logger_t> log;
 
-    // Note that executor `must die` before updater as it contain io loop for
+    // Note that executor `must die` before updater as it contains io loop for
     // updater's inner timer.
     std::shared_ptr<executor::owning_asio_t> executor;
 

--- a/uniresis/src/uniresis.cpp
+++ b/uniresis/src/uniresis.cpp
@@ -124,11 +124,11 @@ public:
 private:
     using self_type = updater_t;
 
-    template<class T, class F>
+    template<class T, class Fn>
     struct weak_wrapper_t {
-        weak_wrapper_t(std::weak_ptr<T> self, F&& fun):
+        weak_wrapper_t(std::weak_ptr<T> self, Fn&& fun):
             self(std::move(self)),
-            fun(std::move(fun))
+            fun(std::move(std::forward<Fn>(fun)))
         {}
 
         template<class... Args>
@@ -139,7 +139,7 @@ private:
         }
 
         std::weak_ptr<T> self;
-        F fun;
+        Fn fun;
     };
 
     template<class Fn>


### PR DESCRIPTION
Introducing signalling on context_t termination. 
- context shutdown signal handler for updater_t clearance and reset;
- thin weak ptr wrapper for updater_t to be used within unicorn callbacks;

**WIP: for early review.**

One of variants, neither yet complete, nor suited well. 