### PR TITLE
Extra `Invalid state` exception handling

### DIFF
--- a/node/src/node.cpp
+++ b/node/src/node.cpp
@@ -111,7 +111,7 @@ class control_slot_t:
         {
             try {
                 if(!node.overseer(name)) {
-                    upstream.abort(error::not_running, "app is not running");
+                    throw cocaine::error_t("no overseer");
                 }
             } catch(const std::system_error& e) {
                 upstream.abort(error::not_running,

--- a/node/src/node.cpp
+++ b/node/src/node.cpp
@@ -109,10 +109,15 @@ class control_slot_t:
             app_name(name),
             upstream(_upstream)
         {
-            auto ovs = node.overseer(name);
-            if(!ovs) {
-                upstream.abort(error::not_running, "app is not running");
+            try {
+                if(!node.overseer(name)) {
+                    upstream.abort(error::not_running, "app is not running");
+                }
+            } catch(const std::system_error& e) {
+                upstream.abort(error::not_running,
+                    cocaine::format("app is not running, {}", e.what()));
             }
+
             catcher_t catcher(upstream);
 
             using chunk = protocol::chunk;


### PR DESCRIPTION
`node::overseer(name)` call chain  in `control_slot_t::dispatch_t` _ctor_ could result in `invalid_state` exception which in turn could be propagated out of dispatch and result in massively annoying `uncaught exception` error wave.

@3Hren, @antmat PTAL.