### PR TITLE
 fix: move scopes' desctruction outside of lock

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-plugins (0.12.14.50) unstable; urgency=medium
+
+  * Fixed: move scopes' desctruction outside of lock
+
+ -- Kirill Smorodinnikov <shaitkir@gmail.com>  Wed, 21 Feb 2018 15:32:09 +0300
+
 cocaine-plugins (0.12.14.49) unstable; urgency=medium
 
   * Non-maintainer upload.


### PR DESCRIPTION
### Motivation
We faced with deadlock caused by two simultaneous failures got from zookeeper: `subscribe` and `children_subscribe` were failed with "connection lost". The first provoked a call of `on_filter()` under corresponding scope's lock that stuck in acquiring scopes' lock in `scopes->erase()`. The second led to clearing `scopes` under its lock which caused destroying all stored scopes and closing them under their lock one by one (due `~scope_wrapper_t()`) and it stuck in acquiring lock of the scope from the first failure. One can see locks order violation.

### Possible solutions

1. Postpone removing the scope in `on_filter()` ([line 238](https://github.com/3Hren/cocaine-plugins/compare/v0.12.14...shaitan:v0.12.14#diff-1c8ab8d714be95d2d1460d133088a73dL238)) until its lock is free, but it leaves unsubscribed scope accessible for a while and can cause to removing resubscribed and correct scope
2. Revert https://github.com/3Hren/cocaine-plugins/pull/195/commits/e4cf733ffeac7c39f79aaa64d9cfa5572ecf4d51 and make another solution for that problem
3. Move scope's destruction outside of `scopes`' lock, so inverted locks order will be avoided

This PR includes changes according to the 3rd solution and it is open for discussion.