### PR TITLE
fix: change the formula for rebalance target

### DIFF
--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -571,7 +571,7 @@ auto engine_t::rebalance_slaves() -> void {
         target = *manual_target;
     } else {
         if (profile.queue_limit > 0) {
-            target = load / profile.grow_threshold;
+            target = (load + profile.grow_threshold - 1) / profile.grow_threshold;
         } else {
             target = pool.apply([&](pool_type& pool) {
                 auto pressure = pool_pressure(pool);


### PR DESCRIPTION
With old formula `target` was zero until `load` exceeds `grow_threshold`, so it doesn't spawn a worker.

With new formula `target` become 1 as soon as `load` becomes nonzero and it will spawn a worker.