### PR TITLE
fix(uniresis): uniresis_t components destruction order

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.14.55) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Fixed: uniresis_t components destruction order.
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Mon, 05 Mar 2018 22:20:36 +0300
+
 cocaine-plugins (0.12.14.54) unstable; urgency=medium
 
   * Fixed: change the formula for rebalance target

--- a/uniresis/include/cocaine/service/uniresis.hpp
+++ b/uniresis/include/cocaine/service/uniresis.hpp
@@ -16,9 +16,8 @@ class uniresis_t : public api::service_t, public dispatch<io::uniresis_tag> {
 
     std::string uuid;
     uniresis::resources_t resources;
-    std::unique_ptr<updater_t> updater;
     std::unique_ptr<logging::logger_t> log;
-
+    std::unique_ptr<updater_t> updater;
 public:
     uniresis_t(context_t& context, asio::io_service& loop, const std::string& name, const dynamic_t& args);
 

--- a/uniresis/src/uniresis.cpp
+++ b/uniresis/src/uniresis.cpp
@@ -93,13 +93,14 @@ public:
     {}
 
     ~updater_t() {
+        timer.cancel();
+
         if(scope) {
             scope->close();
         }
         if (subscope) {
             subscope->close();
         }
-        timer.cancel();
     }
 
     auto


### PR DESCRIPTION
`uniresis_t::updater_t` holds reference to `uniresis_t` logger. But in `uniresis_t` dtor, logger is destroyed first, while it is possiblility that it will be used in `updater_t dtor`, so reorder needed.

Additionally, order of `uniresis_t::updater_t` scopes/timer closing sequence was changed.