### PR TITLE
fix: clear engine_t::observers in overseer_t dtor.

### DIFF
--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -290,6 +290,15 @@ auto engine_t::prototype() -> std::unique_ptr<io::basic_dispatch_t> {
     );
 }
 
+auto engine_t::cancel() -> void {
+    this->stats.deregister();
+    this->stopped = true;
+    this->control_population(boost::none);
+    this->pool->clear();
+    this->on_spawn_rate_timer->reset();
+    this->observers->clear();
+}
+
 auto engine_t::spawn(pool_type& pool) -> void {
     spawn(id_t(), pool);
 }

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -35,13 +35,7 @@ overseer_t::overseer_t(context_t& context,
 
 overseer_t::~overseer_t() {
     COCAINE_LOG_DEBUG(engine->log, "overseer is processing terminate request");
-
-    engine->stats.deregister();
-    engine->stopped = true;
-    engine->control_population(boost::none);
-    engine->pool->clear();
-    engine->on_spawn_rate_timer->reset();
-    engine->observers->clear();
+    engine->cancel();
 }
 
 auto overseer_t::active_workers() const -> std::uint32_t {

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -41,6 +41,7 @@ overseer_t::~overseer_t() {
     engine->control_population(boost::none);
     engine->pool->clear();
     engine->on_spawn_rate_timer->reset();
+    engine->observers->clear();
 }
 
 auto overseer_t::active_workers() const -> std::uint32_t {


### PR DESCRIPTION
`engine_t` could outlive `overseer_t` (and owning `running_t`) object in some async callbacks, but `engine_t` owns observers list, one of which still has reference on running_t in `running_t::observer_adapter_t`. In order to remove dependency, `engine_t::observers` are cleared on `overseer_t` termination.

Another possible solution is to wrap `running_t` in some sort of smart pointer within `running_t::observer_adapter_t`.