### PR TITLE
Unicorn::create with arguments.

### DIFF
--- a/unicorn/include/cocaine/api/v15/unicorn.hpp
+++ b/unicorn/include/cocaine/api/v15/unicorn.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cocaine/api/unicorn.hpp>
+#include <cocaine/dynamic.hpp>
 #include <cocaine/errors.hpp>
 
 namespace cocaine {
@@ -15,6 +16,22 @@ public:
     virtual
     unicorn_scope_ptr
     named_lock(callback::lock callback, const unicorn::path_t& path, const unicorn::value_t& value) = 0;
+
+    virtual
+    unicorn_scope_ptr
+    create_with(callback::create callback, const unicorn::path_t& path, const unicorn::value_t& value, const cocaine::dynamic_t& args) {
+        auto ephemeral = bool{};
+        auto sequential = bool{};
+
+        if (args.is_object()) {
+            const auto& dict = args.as_object();
+
+            ephemeral = dict.at("ephemeral", false).as_bool();
+            sequential = dict.at("sequential", false).as_bool();
+        }
+
+        return this->create(std::move(callback), path, value, ephemeral, sequential);
+    }
 };
 
 typedef std::shared_ptr<unicorn_t> unicorn_ptr;

--- a/unicorn/include/cocaine/idl/unicorn.hpp
+++ b/unicorn/include/cocaine/idl/unicorn.hpp
@@ -84,16 +84,16 @@ struct unicorn {
         * dynamic_t - additional options
         **/
         typedef boost::mpl::list<
-                cocaine::unicorn::path_t,
-                cocaine::unicorn::value_t,
-                cocaine::dynamic_t
+            cocaine::unicorn::path_t,
+            cocaine::unicorn::value_t,
+            cocaine::dynamic_t
         > argument_type;
 
         /**
         * true if node was created. Error on any kind of error
         */
         typedef option_of<
-                bool
+            bool
         >::tag upstream_type;
 
         typedef unicorn_final_tag dispatch_type;

--- a/unicorn/include/cocaine/idl/unicorn.hpp
+++ b/unicorn/include/cocaine/idl/unicorn.hpp
@@ -69,6 +69,37 @@ struct unicorn {
         typedef unicorn_final_tag dispatch_type;
     };
 
+    struct create_with {
+        typedef unicorn_tag tag;
+
+        static const char* alias() {
+            return "create_with";
+        }
+
+        /**
+        * Create a node if it does not exist.
+        *
+        * path_t - path to change.
+        * value_t - value to write in path
+        * dynamic_t - additional options
+        **/
+        typedef boost::mpl::list<
+                cocaine::unicorn::path_t,
+                cocaine::unicorn::value_t,
+                cocaine::dynamic_t
+        > argument_type;
+
+        /**
+        * true if node was created. Error on any kind of error
+        */
+        typedef option_of<
+                bool
+        >::tag upstream_type;
+
+        typedef unicorn_final_tag dispatch_type;
+    };
+
+
     struct put {
         typedef unicorn_tag tag;
 
@@ -299,7 +330,8 @@ struct protocol<unicorn_tag> {
         unicorn::remove,
         unicorn::increment,
         unicorn::lock,
-        unicorn::named_lock
+        unicorn::named_lock,
+        unicorn::create_with
     > messages;
 
     typedef unicorn scope;

--- a/unicorn/src/service/unicorn.cpp
+++ b/unicorn/src/service/unicorn.cpp
@@ -222,7 +222,8 @@ struct method_of {
         boost::mpl::pair<io::unicorn::remove, decltype(&api::v15::unicorn_t::del)>,
         boost::mpl::pair<io::unicorn::increment, decltype(&api::v15::unicorn_t::increment)>,
         boost::mpl::pair<io::unicorn::lock, decltype(&api::v15::unicorn_t::lock)>,
-        boost::mpl::pair<io::unicorn::named_lock, decltype(&api::v15::unicorn_t::named_lock)>
+        boost::mpl::pair<io::unicorn::named_lock, decltype(&api::v15::unicorn_t::named_lock)>,
+        boost::mpl::pair<io::unicorn::create_with, decltype(&api::v15::unicorn_t::create_with)>
     >::type mapping;
 
     typedef typename boost::mpl::at<mapping, Event>::type type;
@@ -281,6 +282,7 @@ unicorn_service_t::unicorn_service_t(context_t& context, asio::io_service& asio_
     r.on<scope::increment>(&api::v15::unicorn_t::increment);
     r.on<scope::lock>(&api::v15::unicorn_t::lock);
     r.on<scope::named_lock>(&api::v15::unicorn_t::named_lock);
+    r.on<scope::create_with>(&api::v15::unicorn_t::create_with);
 }
 
 unicorn_dispatch_t::unicorn_dispatch_t(const std::string& name_) :


### PR DESCRIPTION
PR introduces unicorn::create_with(.., args) that will allow to bypass additional arguments to unicorn::create operation. in case of ZK unicorn backend it'll allow to create an ephemeral node by supplying appropriate flags in `args`. Note that such ephemeral node's lifetime could span entire Cocaine-RT lifetime, not client lifetime, as it seems client couldn't control internal unicorn ZK sessions, but in some use cases it would be exactly what is needed.

Usage from python:
```python
ch = yield unicorn.create_with('/brightvoice/resources', {}, dict(ephemeral=True))`
```
