### PR TITLE
feat(uniresis): get extra locator tags

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-plugins (0.12.14.57) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Feat: uniresis::extra method.
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Tue, 24 Apr 2018 15:18:10 +0300
+
 cocaine-plugins (0.12.14.56) unstable; urgency=medium
 
   * Non-maintainer upload.

--- a/uniresis/include/cocaine/idl/uniresis.hpp
+++ b/uniresis/include/cocaine/idl/uniresis.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <cocaine/rpc/protocol.hpp>
 #include <cocaine/dynamic.hpp>
+#include <cocaine/rpc/protocol.hpp>
 
 
 namespace cocaine {

--- a/uniresis/include/cocaine/idl/uniresis.hpp
+++ b/uniresis/include/cocaine/idl/uniresis.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cocaine/rpc/protocol.hpp>
+#include <cocaine/dynamic.hpp>
+
 
 namespace cocaine {
 namespace io {
@@ -55,6 +57,20 @@ struct uniresis {
             std::string
         >::tag upstream_type;
     };
+
+    struct extra {
+        typedef uniresis_tag tag;
+
+        static constexpr auto alias() -> const char* {
+            return "extra";
+        }
+
+        typedef boost::mpl::list<>::type argument_type;
+
+        typedef option_of<
+            cocaine::dynamic_t
+        >::tag upstream_type;
+    };
 };
 
 template<>
@@ -66,7 +82,8 @@ struct protocol<uniresis_tag> {
     typedef boost::mpl::list<
         uniresis::cpu_count,
         uniresis::memory_count,
-        uniresis::uuid
+        uniresis::uuid,
+        uniresis::extra
     >::type messages;
 };
 

--- a/uniresis/include/cocaine/service/uniresis.hpp
+++ b/uniresis/include/cocaine/service/uniresis.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <cocaine/api/service.hpp>
+#include <cocaine/dynamic.hpp>
 #include <cocaine/rpc/dispatch.hpp>
 
 #include "cocaine/idl/uniresis.hpp"
@@ -18,6 +19,7 @@ class uniresis_t : public api::service_t, public dispatch<io::uniresis_tag> {
     uniresis::resources_t resources;
     std::unique_ptr<logging::logger_t> log;
     std::unique_ptr<updater_t> updater;
+    dynamic_t::object_t extra;
 public:
     uniresis_t(context_t& context, asio::io_service& loop, const std::string& name, const dynamic_t& args);
 

--- a/uniresis/src/uniresis.cpp
+++ b/uniresis/src/uniresis.cpp
@@ -13,6 +13,8 @@
 #include <cocaine/unicorn/value.hpp>
 #include <cocaine/unique_id.hpp>
 
+#include <cocaine/traits/dynamic.hpp>
+
 #include "cocaine/uniresis/error.hpp"
 
 namespace cocaine {
@@ -246,12 +248,13 @@ uniresis_t::uniresis_t(context_t& context, asio::io_service& loop, const std::st
             locator->args().as_object().at("extra_param", dynamic_t::empty_object)
         );
     }
+
     auto unicorn = api::unicorn(context, args.as_object().at("unicorn", defaults::unicorn_name).as_string());
     updater.reset(new updater_t(
         std::move(path),
         std::move(hostname),
         std::move(endpoints),
-        std::move(extra),
+        extra,
         resources,
         std::move(unicorn),
         *log
@@ -268,6 +271,15 @@ uniresis_t::uniresis_t(context_t& context, asio::io_service& loop, const std::st
 
     on<io::uniresis::uuid>([&] {
         return uuid;
+    });
+
+    on<io::uniresis::extra>([=] {
+        // Note that `extra` must be captured (copied) by value, as it
+        // originally lives on ctor stack.
+        //
+        // Alternatively it is possible to capture context and retrieve
+        // cluster extra tags on every call.
+        return extra;
     });
 }
 

--- a/uniresis/src/uniresis.cpp
+++ b/uniresis/src/uniresis.cpp
@@ -8,7 +8,6 @@
 #include <cocaine/api/unicorn.hpp>
 #include <cocaine/context.hpp>
 #include <cocaine/context/config.hpp>
-#include <cocaine/dynamic.hpp>
 #include <cocaine/executor/asio.hpp>
 #include <cocaine/unicorn/value.hpp>
 #include <cocaine/unique_id.hpp>
@@ -242,7 +241,6 @@ uniresis_t::uniresis_t(context_t& context, asio::io_service& loop, const std::st
 
     auto hostname = context.config().network().hostname();
     auto endpoints = resolve(hostname);
-    dynamic_t::object_t extra;
     if (auto locator = context.config().services().get("locator")) {
         extra = dynamic_converter<dynamic_t::object_t>::convert(
             locator->args().as_object().at("extra_param", dynamic_t::empty_object)
@@ -273,13 +271,8 @@ uniresis_t::uniresis_t(context_t& context, asio::io_service& loop, const std::st
         return uuid;
     });
 
-    on<io::uniresis::extra>([=] {
-        // Note that `extra` must be captured (copied) by value, as it
-        // originally lives on ctor stack.
-        //
-        // Alternatively it is possible to capture context and retrieve
-        // cluster extra tags on every call.
-        return extra;
+    on<io::uniresis::extra>([&] {
+        return this->extra;
     });
 }
 


### PR DESCRIPTION
subj. would be nice to have as first step to implement simple sharding, as it could simplify automatic unicorn paths setup based on local node info (extra locator's tags) by orchestration subsystem.