### PR TITLE
Throw on overseer request within wrong app state

### DIFF
--- a/node/include/cocaine/idl/node.hpp
+++ b/node/include/cocaine/idl/node.hpp
@@ -273,7 +273,12 @@ enum node_errors {
     /// The isolate plugin has failed its contract and has thrown non `system_error` exception.
     /// Checking logs may help to determine what was happened.
     uncaught_spool_error,
-    uncaught_publish_error
+    uncaught_publish_error,
+
+    /// Used to signal clinet that app is not ready for `control` command.
+    inactive_on_spool,
+    inactive_on_stop,
+    inactive_on_broken
 };
 
 const std::error_category&

--- a/node/src/node/app.cpp
+++ b/node/src/node/app.cpp
@@ -283,6 +283,16 @@ public:
 
         return info;
     }
+
+    virtual
+    std::shared_ptr<overseer_t>
+    overseer() const override {
+        if (ec) {
+            throw std::system_error(error::inactive_on_broken, cocaine::format("app in broken state: '{}'", ec.message()));
+        }
+
+        throw std::system_error(error::inactive_on_stop, "app is stopped");
+    }
 };
 
 /// The application is currently spooling.
@@ -335,6 +345,12 @@ public:
         dynamic_t::object_t info;
         info["state"] = "spooling";
         return info;
+    }
+
+    virtual
+    std::shared_ptr<overseer_t>
+    overseer() const override {
+        throw std::system_error(error::inactive_on_spool, "app is spooling");
     }
 };
 

--- a/node/src/node/error.cpp
+++ b/node/src/node/error.cpp
@@ -35,6 +35,12 @@ struct node_category_t:
             return "uncaught error while spooling app";
         case node_errors::uncaught_publish_error:
             return "uncaught error while publishing app";
+        case node_errors::inactive_on_spool:
+            return "inactive in spooling state";
+        case node_errors::inactive_on_stop:
+            return "inactive in stopped state";
+        case node_errors::inactive_on_broken:
+            return "inactive in broken state";
         default:
             break;
         }


### PR DESCRIPTION
subj. 

Within orchestration/scheduling stuff we need to distinguish between different overseer retrieving failure cases. It could be used to avoid scheduling flaps on long apps spooling.