### PR TITLE
feat: postmortem engine_t sequence

### DIFF
--- a/node/include/cocaine/service/node/overseer.hpp
+++ b/node/include/cocaine/service/node/overseer.hpp
@@ -102,6 +102,9 @@ public:
     /// The handshake message should contain its peer id (likely uuid) by comparing that we either
     /// accept the session or drop it.
     auto prototype() -> std::unique_ptr<io::basic_dispatch_t>;
+
+    /// TODO: Docs.
+    auto stopped_by_control() const -> bool;
 };
 
 }  // namespace node

--- a/node/include/cocaine/service/node/profile.hpp
+++ b/node/include/cocaine/service/node/profile.hpp
@@ -47,6 +47,7 @@ struct profile_t : cached<dynamic_t> {
         unsigned long seal;
         unsigned long terminate;
         unsigned long idle;
+        unsigned long death;
     } timeout;
 
     // Limits.

--- a/node/src/node/engine.cpp
+++ b/node/src/node/engine.cpp
@@ -175,16 +175,19 @@ auto engine_t::control_population(boost::optional<std::size_t> count) -> void {
 
     pool_target.apply([&](boost::optional<std::size_t>& pool_target) {
         if (pool_target == count) {
+            COCAINE_LOG_DEBUG(log, "pool target wasn't updated, skipping (re)publish step");
             return;
         }
 
-        if (pool_target == 0) {
+        const auto zero = std::size_t{0};
+
+        if (pool_target == zero) {
             observers.apply([] (const observers_type& observers) {
                 for (const auto& o : observers) {
                     o->maybe_publish();
                 }
             });
-        } else if (count == 0) {
+        } else if (count == zero) {
             observers.apply([] (const observers_type& observers) {
                 for (const auto& o : observers) {
                     o->forced_unpublish();
@@ -683,6 +686,8 @@ auto engine_t::rebalance_slaves() -> void {
                 {"slaves", pool.size()},
                 {"target", target},
             });
+
+            on_postmortem_timer->reset();
 
             if (pool.size() >= profile.pool_limit) {
                 return;

--- a/node/src/node/engine.hpp
+++ b/node/src/node/engine.hpp
@@ -64,6 +64,8 @@ public:
     synchronized<pool_type> pool;
     synchronized<boost::optional<std::size_t>> pool_target;
     synchronized<std::unique_ptr<asio::deadline_timer>> on_spawn_rate_timer;
+    synchronized<std::unique_ptr<asio::deadline_timer>> on_postmortem_timer;
+
     std::chrono::system_clock::time_point last_failed;
     std::chrono::seconds last_timeout;
 
@@ -170,6 +172,8 @@ public:
     // currently unused, defined for symmetry.
     auto start_isolate_metrics_poll() -> void;
     auto stop_isolate_metrics_poll() -> void;
+
+    auto stopped_by_control() const -> bool;
 private:
     /// Spawns a slave using current manifest and profile.
     auto spawn(pool_type& pool) -> void;
@@ -202,6 +206,8 @@ private:
     auto rebalance_slaves() -> void;
 
     auto on_spawn_rate_timeout(const std::error_code& ec) -> void;
+
+    auto start_postmortem_sequence(pool_type&) -> void;
 };
 
 }  // namespace node

--- a/node/src/node/overseer.cpp
+++ b/node/src/node/overseer.cpp
@@ -78,6 +78,10 @@ auto overseer_t::prototype() -> std::unique_ptr<io::basic_dispatch_t> {
     return engine->prototype();
 }
 
+auto overseer_t::stopped_by_control() const -> bool {
+    return engine->stopped_by_control();
+}
+
 }  // namespace node
 }  // namespace service
 }  // namespace cocaine

--- a/node/src/node/pool_observer.hpp
+++ b/node/src/node/pool_observer.hpp
@@ -18,6 +18,14 @@ public:
     virtual
     auto
     despawned(const std::string& id) -> void = 0;
+
+    virtual
+    auto
+    forced_unpublish() -> void {}
+
+    virtual
+    auto
+    maybe_publish() -> void {}
 };
 
 } // namespace node

--- a/node/src/node/profile.cpp
+++ b/node/src/node/profile.cpp
@@ -41,6 +41,7 @@ profile_t::profile_t(context_t& context, const std::string& name_):
     timeout.seal      = static_cast<uint64_t>(1000 * config.at("seal-timeout", 60.0).to<double>());
     timeout.terminate = static_cast<uint64_t>(1000 * config.at("terminate-timeout", 10.0).to<double>());
     timeout.idle      = static_cast<uint64_t>(1000 * config.at("idle-timeout", 600.0f).to<double>());
+    timeout.death     = static_cast<uint64_t>(1000 * config.at("death-timeout", 60.0f).to<double>());
     //timeout.request   = static_cast<uint64_t>(1000 * config.at("request-timeout", 86400.0f).to<double>());
 
     concurrency         = as_object().at("concurrency", 10L).to<uint64_t>();


### PR DESCRIPTION
This patch intended to prevent node service queues overflow when stopped by `app.control(0)` state.    

Unpublish application immediately after `app.control(0) client call, move all workers to deferred pool, and re-balance remaining load on them, clear main workers pool. Meanwhile start to return protocol error 'app has been stopped' on already connected clients `enqueue` attempts.

After configured (within profile) timeout, drop deferred pool and queue and remain in `stopped` state until another `app.control(x)` message.

Scheme is arguable as it seems that just unpublish and throw 'app has been stopped' to connected peers would be enough.